### PR TITLE
docs: Issue와 PR 운영 규칙 정리

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -218,6 +218,26 @@ git push --force-with-lease origin feature/user-auth
 
 ## Pull Request Workflow
 
+### Ssartnership Issue / PR Rules
+
+Use this repository-specific flow when the user asks to create Issues, PRs, branches, or to close an Issue after implementation:
+
+1. Create or identify a GitHub Issue before code changes when the work is planned rather than an immediate one-line fix.
+2. Create branches from the current base branch using a type prefix that matches the work:
+   - `feat/*` for new user-facing or admin-facing functionality
+   - `fix/*` for production/runtime bugs
+   - `refactor/*` for behavior-preserving UI, structure, or code cleanup
+   - `perf/*` for performance improvements
+   - `chore/*` for maintenance, contact/config updates, and workflow housekeeping
+   - `docs/*`, `test/*`, `ci/*` for documentation, tests, and CI-only changes
+3. Keep PRs focused. Split work into multiple PRs when the changes are independently reviewable or when the user requests separation.
+4. Link PRs to Issues explicitly:
+   - Use `Refs #<issue-number>` when multiple PRs share one Issue.
+   - Use `Closes #<issue-number>` only when that PR alone fully resolves the Issue on merge.
+5. For multi-PR Issues, close the Issue only after the final PR has merged and the acceptance criteria are satisfied.
+6. Before opening a PR, review `git diff`, run focused verification, and include the exact verification commands/results in the PR body.
+7. When the user asks to commit and push, use `npm run release` unless the task is explicitly PR-only or the release script is blocked after partially completing.
+
 ### PR Title Format
 
 ```

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,57 @@
+name: Task
+description: 계획된 기능, 수정, 리팩터링 작업을 추적합니다.
+title: "[Task] "
+labels: []
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: 목표
+      description: 이 Issue가 해결해야 하는 사용자/운영 관점의 목표를 적어 주세요.
+      placeholder: 예) Footer 연락처와 지원 이메일을 최신 운영 기준에 맞춘다.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 변경 범위
+      description: 포함할 작업과 제외할 작업을 구분해 주세요.
+      placeholder: |
+        포함:
+        - Footer 인스타그램 링크 제거
+        - 지원 이메일 변경
+
+        제외:
+        - 제휴처 연락처 파싱 로직 변경
+    validations:
+      required: true
+  - type: textarea
+    id: pr-plan
+    attributes:
+      label: PR 분리 계획
+      description: 하나의 Issue에 여러 PR이 필요하면 PR 단위와 브랜치 이름을 적어 주세요.
+      placeholder: |
+        - PR 1: refactor/remove-footer-instagram
+        - PR 2: chore/update-support-email
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 완료 기준
+      description: Issue를 닫기 전에 확인할 수 있는 완료 기준을 적어 주세요.
+      placeholder: |
+        - Footer에서 Instagram 버튼이 보이지 않는다.
+        - 모든 지원 메일 수신 주소가 myknow@ssafy.com이다.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: 검증 계획
+      description: 실행할 명령 또는 수동 확인 시나리오를 적어 주세요.
+      placeholder: |
+        - npx eslint src/components/Footer.tsx src/lib/site.ts
+        - rg -n "myknow00@naver\\.com|myknow@ssafy\\.com" src
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+-
+
+## Related Issue
+
+Refs #
+
+> 단일 PR이 Issue를 완전히 해결하는 경우에만 `Closes #`를 사용합니다. 하나의 Issue에 여러 PR이 연결되면 모든 PR은 `Refs #`를 사용하고 마지막 PR 병합 후 Issue를 수동으로 닫습니다.
+
+## Changes
+
+-
+
+## Test Plan
+
+-
+
+## Checklist
+
+- [ ] 변경 범위가 Issue와 일치합니다.
+- [ ] 브랜치명이 작업 성격에 맞는 prefix를 사용합니다. (`feat/*`, `fix/*`, `refactor/*`, `perf/*`, `chore/*`, `docs/*`, `test/*`, `ci/*`)
+- [ ] 관련 Issue가 PR 본문에 연결되어 있습니다.
+- [ ] `git diff`를 검토했습니다.
+- [ ] 필요한 집중 검증을 실행하고 결과를 Test Plan에 적었습니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,12 @@ Run `next build` only when the change touches build/runtime behavior broadly or 
 - If `npm run release` is blocked by a non-script environment issue after it already performed part of the release flow, inspect the partial state first, then complete only the remaining equivalent steps with the same Korean conventional commit message.
 - Do not revert user changes.
 - Review `git diff` before staging or committing.
+
+## GitHub Issue / PR Workflow
+
+- For planned work, create or identify a GitHub Issue before changing code.
+- Use branch names that match the work type: `feat/*`, `fix/*`, `refactor/*`, `perf/*`, `chore/*`, `docs/*`, `test/*`, or `ci/*`.
+- Create one focused PR per independently reviewable change. If one Issue needs multiple PRs, link each PR with `Refs #<issue-number>`.
+- Use `Closes #<issue-number>` only when a single PR fully resolves the Issue on merge. For multi-PR work, close the Issue manually after the final PR is merged.
+- PR descriptions must include Summary, Related Issue, Changes, Test Plan, and Checklist.
+- Before opening or updating a PR, review the diff and run focused verification appropriate to the changed files.


### PR DESCRIPTION
## Summary
- Issue/PR 운영 규칙을 AGENTS.md와 git-workflow skill에 추가합니다.
- GitHub Issue 템플릿과 PR 템플릿을 추가합니다.

## Related Issue
Refs #1

## Changes
- 작업 전 Issue 생성, 작업 성격별 branch prefix, PR-Issue 연결 규칙을 문서화했습니다.
- multi-PR Issue에서는 PR 본문에 Refs를 쓰고 마지막 병합 후 Issue를 수동 close하도록 명시했습니다.
- GitHub Task Issue 템플릿과 Pull Request 템플릿을 추가했습니다.

## Test Plan
- rg -n "Refs #|Closes #|feat/|refactor/|chore/" AGENTS.md .agents/skills/git-workflow/SKILL.md .github
- git push pre-push hook 통과: lint, test, build

## Checklist
- [x] 변경 범위가 Issue와 일치합니다.
- [x] 브랜치명이 작업 성격에 맞는 prefix를 사용합니다.
- [x] 관련 Issue가 PR 본문에 연결되어 있습니다.
- [x] git diff를 검토했습니다.
- [x] 필요한 집중 검증을 실행하고 결과를 Test Plan에 적었습니다.