### PR TITLE
refactor: Footer 인스타그램 링크 제거

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { FaGithub, FaInstagram } from "react-icons/fa";
+import { FaGithub } from "react-icons/fa";
 import {
   BellIcon,
   BugAntIcon,
@@ -18,7 +18,6 @@ import Button from "@/components/ui/Button";
 import Container from "@/components/ui/Container";
 import {
   GITHUB_URL,
-  INSTAGRAM_URL,
   SITE_NAME,
 } from "@/lib/site";
 import { BUG_REPORT_HREF } from "@/lib/support-mail";
@@ -95,16 +94,6 @@ export default function Footer() {
             >
               <FaGithub className="h-5 w-5" />
               {githubHandle}
-            </Button>
-            <Button
-              variant="secondary"
-              href={INSTAGRAM_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="w-full justify-start gap-2"
-            >
-              <FaInstagram className="h-5 w-5 text-[#E1306C]" />
-              @myknow00
             </Button>
           </FooterSection>
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -203,5 +203,4 @@ export const SITE_URL =
 export const SITE_RSS_URL = "/rss.xml";
 
 export const GITHUB_URL = "https://github.com/MyKnow";
-export const INSTAGRAM_URL = "https://instagram.com/myknow00";
 export const BUG_REPORT_EMAIL = "myknow00@naver.com";


### PR DESCRIPTION
## Summary
- Footer 문의 섹션에서 개인 Instagram 링크를 제거합니다.
- Footer 외 사용처가 없는 INSTAGRAM_URL 상수를 제거합니다.

## Related Issue
Refs #1

## Changes
- Footer의 Instagram 아이콘 버튼과 관련 import를 제거했습니다.
- src/lib/site.ts에서 INSTAGRAM_URL 상수를 제거했습니다.

## Test Plan
- rg -n "INSTAGRAM_URL|FaInstagram|@myknow00|instagram.com/myknow00" src/components/Footer.tsx src/lib/site.ts → 결과 없음
- npx eslint src/components/Footer.tsx src/lib/site.ts
- git push pre-push hook 통과: lint, test, build

## Checklist
- [x] 변경 범위가 Issue와 일치합니다.
- [x] 브랜치명이 작업 성격에 맞는 prefix를 사용합니다.
- [x] 관련 Issue가 PR 본문에 연결되어 있습니다.
- [x] git diff를 검토했습니다.
- [x] 필요한 집중 검증을 실행하고 결과를 Test Plan에 적었습니다.