### PR TITLE
chore: 지원 이메일 수신 주소 변경

### DIFF
--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -204,4 +204,4 @@ export const SITE_RSS_URL = "/rss.xml";
 
 export const GITHUB_URL = "https://github.com/MyKnow";
 export const INSTAGRAM_URL = "https://instagram.com/myknow00";
-export const BUG_REPORT_EMAIL = "myknow00@naver.com";
+export const BUG_REPORT_EMAIL = "myknow@ssafy.com";


### PR DESCRIPTION
## Summary
- 버그 제보와 협력사 기술 지원 템플릿이 사용하는 지원 이메일 수신 주소를 변경합니다.

## Related Issue
Refs #1

## Changes
- BUG_REPORT_EMAIL을 myknow00@naver.com에서 myknow@ssafy.com으로 변경했습니다.
- support-mail 템플릿은 중앙 상수를 사용하므로 새 주소를 자동으로 사용합니다.

## Test Plan
- rg -n "myknow00@naver\.com|myknow@ssafy\.com" src → src/lib/site.ts의 myknow@ssafy.com만 확인
- npx eslint src/lib/site.ts src/lib/support-mail.ts
- git push pre-push hook 통과: lint, test, build

## Checklist
- [x] 변경 범위가 Issue와 일치합니다.
- [x] 브랜치명이 작업 성격에 맞는 prefix를 사용합니다.
- [x] 관련 Issue가 PR 본문에 연결되어 있습니다.
- [x] git diff를 검토했습니다.
- [x] 필요한 집중 검증을 실행하고 결과를 Test Plan에 적었습니다.