### PR TITLE
chore: SMTP 설정 일반화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,74 @@
+# Admin credentials
+ADMIN_ID=admin
+ADMIN_PASSWORD=change-me
+ADMIN_SESSION_SECRET=replace-with-long-random-string
+
+# Partner portal
+PARTNER_SESSION_SECRET=replace-with-long-random-string
+# Optional: restrict admin paths to fixed client IPs
+# ADMIN_ALLOWED_IPS=127.0.0.1,203.0.113.10
+# Optional: add HTTP Basic Auth in front of /admin and admin APIs
+# ADMIN_BASIC_AUTH_USERNAME=admin-gateway
+# ADMIN_BASIC_AUTH_PASSWORD=change-me-too
+
+# Supabase
+# Supabase project values
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+
+# Data source
+# NEXT_PUBLIC_DATA_SOURCE=mock
+# Optional override for partner portal only; otherwise follows NEXT_PUBLIC_DATA_SOURCE
+# NEXT_PUBLIC_PARTNER_PORTAL_DATA_SOURCE=mock
+
+# SMTP (for suggestion notifications and partner portal password reset)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=myknow@ssafy.com
+SMTP_PASS=your-smtp-password
+# Optional: override the visible sender address when it differs from SMTP_USER
+# SMTP_FROM_EMAIL=myknow@ssafy.com
+# Optional: only for legacy SMTP servers that fail TLS with "dh key too small"
+# SMTP_TLS_MIN_DH_SIZE=512
+# SMTP_TLS_CIPHERS=DEFAULT@SECLEVEL=0
+# Temporary fallback for existing Naver SMTP deployments:
+# NAVER_SMTP_USER=your-naver-id@naver.com
+# NAVER_SMTP_PASS=your-naver-smtp-password
+SUGGEST_NOTIFY_EMAIL=myknow@ssafy.com
+
+# Mattermost (SSAFY)
+MM_BASE_URL=https://meeting.ssafy.com
+# MM_SENDER_LOGIN_ID=myknow
+# MM_SENDER_PASSWORD=change-me
+# MM_TEAM_NAME=s15public
+MM_STUDENT_CHANNEL=off-topic
+
+# 기수별로 팀명/채널명이 다르면 아래처럼 덮어쓸 수 있습니다.
+## 14기
+MM_SENDER_LOGIN_ID_14=myknow14
+MM_SENDER_PASSWORD_14=change-me-14
+MM_TEAM_NAME_14=s14public
+MM_STUDENT_CHANNEL_14=off-topic
+
+## 15기
+MM_SENDER_LOGIN_ID_15=myknow15
+MM_SENDER_PASSWORD_15=change-me-15
+MM_TEAM_NAME_15=s15public
+MM_STUDENT_CHANNEL_15=off-topic
+
+# User session
+USER_SESSION_SECRET=replace-with-long-random-string
+MM_VERIFICATION_SECRET=replace-with-long-random-string
+CERTIFICATION_QR_SECRET=replace-with-long-random-string
+
+# Web Push
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=replace-with-vapid-public-key
+VAPID_PRIVATE_KEY=replace-with-vapid-private-key
+VAPID_SUBJECT=mailto:myknow@ssafy.com
+CRON_SECRET=replace-with-long-random-string
+
+# Site URL (SEO)
+NEXT_PUBLIC_SITE_URL=https://ssartnership.myknow.xyz

--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import nodemailer from "nodemailer";
 import {
   getRequestLogContext,
   logProductEvent,
   resolveCurrentActor,
 } from "@/lib/activity-logs";
 import { BUG_REPORT_EMAIL } from "@/lib/site";
+import { createSmtpTransport, getSmtpConfig } from "@/lib/smtp";
 import { isBlocked, recordAttempt, SUGGEST_RATE_LIMIT } from "@/lib/rate-limit";
 import { isValidEmail, sanitizeHttpUrl } from "@/lib/validation";
 
@@ -91,11 +91,11 @@ export async function POST(request: Request) {
 
     await recordAttempt(identifier, false, SUGGEST_RATE_LIMIT);
 
-    const smtpUser = process.env.NAVER_SMTP_USER;
-    const smtpPass = process.env.NAVER_SMTP_PASS;
     const recipient = process.env.SUGGEST_NOTIFY_EMAIL ?? BUG_REPORT_EMAIL;
-
-    if (!smtpUser || !smtpPass) {
+    let smtpConfig: ReturnType<typeof getSmtpConfig>;
+    try {
+      smtpConfig = getSmtpConfig();
+    } catch {
       return errorResponse(
         "메일 설정이 누락되었습니다.",
         503,
@@ -103,15 +103,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const transporter = nodemailer.createTransport({
-      host: "smtp.naver.com",
-      port: 465,
-      secure: true,
-      auth: {
-        user: smtpUser,
-        pass: smtpPass,
-      },
-    });
+    const transporter = createSmtpTransport(smtpConfig);
 
     const subject = `[SSARTNERSHIP] 제휴 제안 접수 안내`;
     const safeCompanyName = toHtml(payload.companyName ?? "");
@@ -135,7 +127,7 @@ export async function POST(request: Request) {
     const bodyHtml = `\n      <div style=\"font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif; color: #0f172a; line-height: 1.7;\">\n        <h2 style=\"margin: 0 0 12px;\">제휴 제안을 접수했습니다.</h2>\n        <p style=\"margin: 0 0 16px; color: #334155;\">\n          안녕하세요 ${safeContactName} ${safeContactRole}님,\n          SSARTNERSHIP 파트너십 제안을 보내주셔서 감사합니다.\n          보내주신 내용을 아래와 같이 정리해 전달드립니다.\n        </p>\n        <div style=\"border: 1px solid #e2e8f0; border-radius: 16px; padding: 16px; background: #f8fafc;\">\n          <p style=\"margin: 0 0 8px;\"><strong>업체명</strong><br />${safeCompanyName}</p>\n          <p style=\"margin: 0 0 8px;\"><strong>업체분야 소개</strong><br />${safeBusiness}</p>\n          <p style=\"margin: 0 0 8px;\"><strong>제안 제휴 조건</strong><br />${safeConditions}</p>\n          <p style=\"margin: 0 0 8px;\"><strong>담당자</strong><br />${safeContactName} ${safeContactRole}</p>\n          <p style=\"margin: 0 0 8px;\"><strong>담당자 이메일</strong><br />${safeContactEmail}</p>\n          <p style=\"margin: 0;\"><strong>회사 사이트</strong><br />${safeCompanyUrl}</p>\n        </div>\n        <p style=\"margin: 16px 0 0; color: #334155;\">\n          담당자가 확인 후 안내드리겠습니다. 추가로 전달하실 내용이 있으면\n          이 메일에 회신해 주세요.\n        </p>\n        <p style=\"margin: 20px 0 0; color: #64748b; font-size: 12px;\">\n          SSARTNERSHIP · SSAFY 15기 서울 캠퍼스\n        </p>\n      </div>\n    `;
 
     await transporter.sendMail({
-      from: `SSARTNERSHIP <${smtpUser}>`,
+      from: `SSARTNERSHIP <${smtpConfig.fromEmail}>`,
       to: payload.contactEmail,
       bcc: recipient,
       replyTo: payload.contactEmail,

--- a/src/lib/partner-email.ts
+++ b/src/lib/partner-email.ts
@@ -1,14 +1,5 @@
-import nodemailer from "nodemailer";
 import { SITE_NAME } from "./site";
-
-function getSmtpCredentials() {
-  const smtpUser = process.env.NAVER_SMTP_USER;
-  const smtpPass = process.env.NAVER_SMTP_PASS;
-  if (!smtpUser || !smtpPass) {
-    throw new Error("메일 설정이 누락되었습니다.");
-  }
-  return { smtpUser, smtpPass };
-}
+import { createSmtpTransport, getSmtpConfig } from "./smtp";
 
 function escapeHtml(value: string) {
   return value
@@ -29,23 +20,15 @@ export async function sendPartnerPortalTemporaryPasswordEmail(input: {
   loginId: string;
   temporaryPassword: string;
 }) {
-  const { smtpUser, smtpPass } = getSmtpCredentials();
-  const transporter = nodemailer.createTransport({
-    host: "smtp.naver.com",
-    port: 465,
-    secure: true,
-    auth: {
-      user: smtpUser,
-      pass: smtpPass,
-    },
-  });
+  const smtpConfig = getSmtpConfig();
+  const transporter = createSmtpTransport(smtpConfig);
 
   const safeDisplayName = toHtml(input.displayName || "담당자");
   const safeLoginId = toHtml(input.loginId);
   const safeTemporaryPassword = toHtml(input.temporaryPassword);
 
   await transporter.sendMail({
-    from: `${SITE_NAME} <${smtpUser}>`,
+    from: `${SITE_NAME} <${smtpConfig.fromEmail}>`,
     to: input.to,
     subject: `[${SITE_NAME}] 협력사 포털 임시 비밀번호 안내`,
     text: [
@@ -82,23 +65,15 @@ export async function sendPartnerPortalInitialSetupEmail(input: {
   loginId: string;
   setupUrl: string;
 }) {
-  const { smtpUser, smtpPass } = getSmtpCredentials();
-  const transporter = nodemailer.createTransport({
-    host: "smtp.naver.com",
-    port: 465,
-    secure: true,
-    auth: {
-      user: smtpUser,
-      pass: smtpPass,
-    },
-  });
+  const smtpConfig = getSmtpConfig();
+  const transporter = createSmtpTransport(smtpConfig);
 
   const safeDisplayName = toHtml(input.displayName || "담당자");
   const safeLoginId = toHtml(input.loginId);
   const safeSetupUrl = escapeHtml(input.setupUrl);
 
   await transporter.sendMail({
-    from: `${SITE_NAME} <${smtpUser}>`,
+    from: `${SITE_NAME} <${smtpConfig.fromEmail}>`,
     to: input.to,
     subject: `[${SITE_NAME}] 협력사 포털 초기 설정 안내`,
     text: [

--- a/src/lib/smtp.ts
+++ b/src/lib/smtp.ts
@@ -1,0 +1,132 @@
+import nodemailer from "nodemailer";
+
+export type SmtpConfig = {
+  host: string;
+  port: number;
+  secure: boolean;
+  user: string;
+  pass: string;
+  fromEmail: string;
+  tlsMinDhSize?: number;
+  tlsCiphers?: string;
+};
+
+function parseSmtpPort(value?: string) {
+  if (!value) {
+    return 465;
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error("SMTP_PORT 설정이 올바르지 않습니다.");
+  }
+
+  return port;
+}
+
+function parseSmtpSecure(value: string | undefined, port: number) {
+  if (!value) {
+    return port === 465;
+  }
+
+  return value.trim().toLowerCase() !== "false";
+}
+
+function parseOptionalPositiveInteger(value: string | undefined, name: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} 설정이 올바르지 않습니다.`);
+  }
+
+  return parsed;
+}
+
+function hasAnyValue(values: Array<string | undefined>) {
+  return values.some((value) => Boolean(value?.trim()));
+}
+
+export function getSmtpConfig(env: NodeJS.ProcessEnv = process.env): SmtpConfig {
+  const hasGenericSmtpConfig = hasAnyValue([
+    env.SMTP_HOST,
+    env.SMTP_PORT,
+    env.SMTP_SECURE,
+    env.SMTP_USER,
+    env.SMTP_PASS,
+    env.SMTP_FROM_EMAIL,
+  ]);
+
+  if (hasGenericSmtpConfig) {
+    const port = parseSmtpPort(env.SMTP_PORT);
+    const secure = parseSmtpSecure(env.SMTP_SECURE, port);
+    const fromEmail = env.SMTP_FROM_EMAIL ?? env.SMTP_USER;
+    const tlsMinDhSize = parseOptionalPositiveInteger(
+      env.SMTP_TLS_MIN_DH_SIZE,
+      "SMTP_TLS_MIN_DH_SIZE",
+    );
+    const tlsCiphers = env.SMTP_TLS_CIPHERS;
+
+    if (!env.SMTP_HOST || !env.SMTP_USER || !env.SMTP_PASS || !fromEmail) {
+      throw new Error("SMTP 설정이 불완전합니다.");
+    }
+
+    return {
+      host: env.SMTP_HOST,
+      port,
+      secure,
+      user: env.SMTP_USER,
+      pass: env.SMTP_PASS,
+      fromEmail,
+      ...(tlsMinDhSize ? { tlsMinDhSize } : {}),
+      ...(tlsCiphers ? { tlsCiphers } : {}),
+    };
+  }
+
+  const port = 465;
+  const secure = true;
+  const fromEmail = env.NAVER_SMTP_USER;
+  const tlsMinDhSize = parseOptionalPositiveInteger(
+    env.SMTP_TLS_MIN_DH_SIZE,
+    "SMTP_TLS_MIN_DH_SIZE",
+  );
+  const tlsCiphers = env.SMTP_TLS_CIPHERS;
+
+  if (!env.NAVER_SMTP_USER || !env.NAVER_SMTP_PASS || !fromEmail) {
+    throw new Error("메일 설정이 누락되었습니다.");
+  }
+
+  return {
+    host: "smtp.naver.com",
+    port,
+    secure,
+    user: env.NAVER_SMTP_USER,
+    pass: env.NAVER_SMTP_PASS,
+    fromEmail,
+    ...(tlsMinDhSize ? { tlsMinDhSize } : {}),
+    ...(tlsCiphers ? { tlsCiphers } : {}),
+  };
+}
+
+export function createSmtpTransport(config = getSmtpConfig()) {
+  const tls =
+    config.tlsMinDhSize || config.tlsCiphers
+      ? {
+          ...(config.tlsMinDhSize ? { minDHSize: config.tlsMinDhSize } : {}),
+          ...(config.tlsCiphers ? { ciphers: config.tlsCiphers } : {}),
+        }
+      : undefined;
+
+  return nodemailer.createTransport({
+    host: config.host,
+    port: config.port,
+    secure: config.secure,
+    ...(tls ? { tls } : {}),
+    auth: {
+      user: config.user,
+      pass: config.pass,
+    },
+  });
+}

--- a/tests/smtp-config.test.mts
+++ b/tests/smtp-config.test.mts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSmtpConfig } from "@/lib/smtp";
+
+test("smtp config prefers generic SMTP env values", () => {
+  const config = getSmtpConfig({
+    SMTP_HOST: "smtp.ssafy.com",
+    SMTP_PORT: "587",
+    SMTP_SECURE: "false",
+    SMTP_USER: "myknow@ssafy.com",
+    SMTP_PASS: "secret",
+    SMTP_FROM_EMAIL: "support@ssafy.com",
+    SMTP_TLS_MIN_DH_SIZE: "512",
+    SMTP_TLS_CIPHERS: "DEFAULT@SECLEVEL=0",
+    NAVER_SMTP_USER: "legacy@naver.com",
+    NAVER_SMTP_PASS: "legacy-secret",
+  });
+
+  assert.deepEqual(config, {
+    host: "smtp.ssafy.com",
+    port: 587,
+    secure: false,
+    user: "myknow@ssafy.com",
+    pass: "secret",
+    fromEmail: "support@ssafy.com",
+    tlsMinDhSize: 512,
+    tlsCiphers: "DEFAULT@SECLEVEL=0",
+  });
+});
+
+test("smtp config keeps Naver fallback during env migration", () => {
+  const config = getSmtpConfig({
+    NAVER_SMTP_USER: "legacy@naver.com",
+    NAVER_SMTP_PASS: "legacy-secret",
+  });
+
+  assert.deepEqual(config, {
+    host: "smtp.naver.com",
+    port: 465,
+    secure: true,
+    user: "legacy@naver.com",
+    pass: "legacy-secret",
+    fromEmail: "legacy@naver.com",
+  });
+});
+
+test("smtp config can apply TLS compatibility options to legacy fallback", () => {
+  const config = getSmtpConfig({
+    NAVER_SMTP_USER: "legacy@naver.com",
+    NAVER_SMTP_PASS: "legacy-secret",
+    SMTP_TLS_MIN_DH_SIZE: "512",
+  });
+
+  assert.equal(config.host, "smtp.naver.com");
+  assert.equal(config.tlsMinDhSize, 512);
+});
+
+test("smtp config requires host, user, and password", () => {
+  assert.throws(
+    () =>
+      getSmtpConfig({
+        SMTP_HOST: "smtp.ssafy.com",
+        SMTP_USER: "myknow@ssafy.com",
+      }),
+    /SMTP 설정이 불완전합니다\./,
+  );
+});
+
+test("smtp config rejects mixed generic and legacy credentials", () => {
+  assert.throws(
+    () =>
+      getSmtpConfig({
+        SMTP_USER: "myknow@ssafy.com",
+        NAVER_SMTP_PASS: "legacy-secret",
+      }),
+    /SMTP 설정이 불완전합니다\./,
+  );
+});
+
+test("smtp config does not let partial generic settings fall back to Naver", () => {
+  assert.throws(
+    () =>
+      getSmtpConfig({
+        SMTP_HOST: "smtp.ssafy.com",
+        NAVER_SMTP_USER: "legacy@naver.com",
+        NAVER_SMTP_PASS: "legacy-secret",
+      }),
+    /SMTP 설정이 불완전합니다\./,
+  );
+});
+
+test("smtp config rejects invalid TLS compatibility options", () => {
+  assert.throws(
+    () =>
+      getSmtpConfig({
+        SMTP_HOST: "smtp.ssafy.com",
+        SMTP_USER: "myknow@ssafy.com",
+        SMTP_PASS: "secret",
+        SMTP_TLS_MIN_DH_SIZE: "small",
+      }),
+    /SMTP_TLS_MIN_DH_SIZE 설정이 올바르지 않습니다\./,
+  );
+});


### PR DESCRIPTION
## Summary

SMTP 발송 설정을 Naver 전용 환경변수에서 범용 SMTP 환경변수 기반으로 일반화합니다.

## Related Issue

Refs #5

## Branch Flow

- Base: `dev`
- Source: `chore/smtp-config-generalization`
- Production promotion: `dev` -> `main` after Preview verification

## Changes

- `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM_EMAIL` 기반 설정 helper 추가
- 기존 `NAVER_SMTP_USER`, `NAVER_SMTP_PASS`는 전환 기간 fallback으로 유지
- 협력사 초기 설정/임시 비밀번호 메일과 제휴 제안 메일 발송 경로를 공통 SMTP 설정으로 통합
- `.env.example`에 `myknow@ssafy.com` 기준 SMTP/수신 주소 예시 추가
- SMTP 설정 파서 테스트 추가

## Test Plan

- [x] `npx eslint src/lib/smtp.ts src/lib/partner-email.ts src/app/api/suggest/route.ts`
- [x] `node --import ./tests/alias-register.mjs --test tests/smtp-config.test.mts`
- [x] pre-push hook: `npm run lint`, `npm run test` 110개, `npm run build`

## Checklist

- [x] Branch was created from `dev`
- [x] PR targets `dev`
- [x] No unrelated changes included
- [x] Issue close behavior uses `Refs #` for partial work

## Preview Env Notes

Preview 배포 전 Vercel Preview 환경변수에 아래 값을 설정해야 합니다.

- `SMTP_HOST`
- `SMTP_PORT`
- `SMTP_SECURE`
- `SMTP_USER`
- `SMTP_PASS`
- `SMTP_FROM_EMAIL` 또는 생략
- `SUGGEST_NOTIFY_EMAIL`
- `VAPID_SUBJECT`