### PR TITLE
fix: 제출 확인 모달 viewport 기준 표시

### DIFF
--- a/src/components/SuggestForm.tsx
+++ b/src/components/SuggestForm.tsx
@@ -369,6 +369,7 @@ export default function SuggestForm() {
         title="제휴 제안 제출"
         description="제안을 제출할까요? 제출 후 홈 화면으로 이동합니다."
         onClose={() => setConfirmOpen(false)}
+        bodyClassName="flex justify-end gap-2"
       >
         <Button
           variant="secondary"

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/cn";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
@@ -22,6 +23,7 @@ export default function Modal({
   bodyClassName?: string;
 }) {
   const shouldReduceMotion = useReducedMotion();
+  const portalRoot = typeof document === "undefined" ? null : document.body;
 
   useEffect(() => {
     if (!open) {
@@ -36,7 +38,11 @@ export default function Modal({
     };
   }, [open]);
 
-  return (
+  if (!portalRoot) {
+    return null;
+  }
+
+  return createPortal(
     <AnimatePresence>
       {open ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-2 sm:px-4 sm:py-6">
@@ -76,6 +82,7 @@ export default function Modal({
           </motion.div>
         </div>
       ) : null}
-    </AnimatePresence>
+    </AnimatePresence>,
+    portalRoot,
   );
 }


### PR DESCRIPTION
## Summary

/suggest 제출 확인 모달이 폼 영역에 종속되어 표시되는 문제를 수정합니다.

## Related Issue

Refs #8

## Branch Flow

- Base: `dev`
- Source: `fix/modal-portal-viewport`
- Production promotion: `dev` -> `main` after Preview verification

## Changes

- 공통 `Modal`을 `document.body` portal로 렌더링
- 조상 레이아웃의 transform/filter/contain 맥락에 의해 `fixed` overlay가 폼 영역으로 제한되는 문제 방지
- 기존 body scroll lock 동작 유지

## Test Plan

- [x] `npx eslint src/components/ui/Modal.tsx src/components/SuggestForm.tsx`
- [x] `npm run build`
- [x] pre-push hook: `lint`, `test` 114개, `build`

## Checklist

- [x] Branch was created from `dev`
- [x] PR targets `dev`
- [x] No unrelated changes included
- [x] Preview에서 /suggest 제출 확인 모달 위치 재검증 필요