### PR TITLE
fix: Preview 동기화 캠퍼스 범위 보정

### DIFF
--- a/scripts/supabase-sync-preview-lib.mjs
+++ b/scripts/supabase-sync-preview-lib.mjs
@@ -49,6 +49,78 @@ const DEFAULT_EXCLUDED_COPY_COLUMNS_BY_TABLE = new Map([
   ],
 ]);
 
+const CAMPUS_SLUGS = [
+  "seoul",
+  "gumi",
+  "daejeon",
+  "busan-ulsan-gyeongnam",
+  "gwangju",
+];
+
+function inferCampusSlugsFromLocation(location) {
+  const normalized = location.trim();
+  if (!normalized) {
+    return CAMPUS_SLUGS;
+  }
+  if (/전국|전\s*지점|전체\s*지점|모든\s*지점|전\s*매장|전체\s*매장|모든\s*매장/.test(normalized)) {
+    return CAMPUS_SLUGS;
+  }
+
+  const slugs = [
+    /서울|강남|역삼|역삼역|선릉|테헤란|봉은사|논현/.test(normalized)
+      ? "seoul"
+      : null,
+    /구미|경북|경상북도/.test(normalized) ? "gumi" : null,
+    /대전|유성|둔산/.test(normalized) ? "daejeon" : null,
+    /부산|울산|경남|창원|김해|양산|해운대|서면/.test(normalized)
+      ? "busan-ulsan-gyeongnam"
+      : null,
+    /광주|전남/.test(normalized) ? "gwangju" : null,
+  ].filter(Boolean);
+
+  return slugs.length > 0 ? slugs : CAMPUS_SLUGS;
+}
+
+function buildPostgresTextArray(values) {
+  return `{${values.join(",")}}`;
+}
+
+function transformKeptValuesForPreview(table, columns, values) {
+  if (table !== "partners") {
+    return {
+      values,
+      changed: false,
+    };
+  }
+
+  const locationIndex = columns.indexOf("location");
+  const campusSlugsIndex = columns.indexOf("campus_slugs");
+  if (locationIndex < 0 || campusSlugsIndex < 0) {
+    return {
+      values,
+      changed: false,
+    };
+  }
+
+  const currentCampusSlugs = values[campusSlugsIndex]?.trim() ?? "";
+  if (currentCampusSlugs && currentCampusSlugs !== "\\N" && currentCampusSlugs !== "{}") {
+    return {
+      values,
+      changed: false,
+    };
+  }
+
+  const nextValues = [...values];
+  nextValues[campusSlugsIndex] = buildPostgresTextArray(
+    inferCampusSlugsFromLocation(values[locationIndex] ?? ""),
+  );
+
+  return {
+    values: nextValues,
+    changed: true,
+  };
+}
+
 export function parseCopyStatement(line) {
   const match = line.match(/^COPY\s+(.+?)\s+\((.+)\)\s+FROM\s+stdin;$/);
   if (!match) {
@@ -105,14 +177,25 @@ export function sanitizeDumpSqlForPreview(
       )
       .filter((columnIndex) => columnIndex >= 0);
 
-    if (keptIndexes.length === copyStatement.columns.length) {
+    const mayTransformValues =
+      copyStatement.table === "partners" &&
+      copyStatement.columns.includes("location") &&
+      copyStatement.columns.includes("campus_slugs");
+
+    if (keptIndexes.length === copyStatement.columns.length && !mayTransformValues) {
       output.push(line);
       continue;
     }
 
-    changed = true;
     const keptColumns = keptIndexes.map((columnIndex) => copyStatement.columns[columnIndex]);
-    output.push(buildCopyStatement(copyStatement.schema, copyStatement.table, keptColumns));
+    const statementLine =
+      keptIndexes.length === copyStatement.columns.length
+        ? line
+        : buildCopyStatement(copyStatement.schema, copyStatement.table, keptColumns);
+    output.push(statementLine);
+    if (keptIndexes.length !== copyStatement.columns.length) {
+      changed = true;
+    }
 
     index += 1;
     while (index < lines.length) {
@@ -126,7 +209,16 @@ export function sanitizeDumpSqlForPreview(
       if (values.length !== copyStatement.columns.length) {
         output.push(dataLine);
       } else {
-        output.push(keptIndexes.map((columnIndex) => values[columnIndex]).join("\t"));
+        const keptValues = keptIndexes.map((columnIndex) => values[columnIndex]);
+        const transformed = transformKeptValuesForPreview(
+          copyStatement.table,
+          keptColumns,
+          keptValues,
+        );
+        if (transformed.changed) {
+          changed = true;
+        }
+        output.push(transformed.values.join("\t"));
       }
       index += 1;
     }

--- a/tests/preview-sync-sanitize.test.mts
+++ b/tests/preview-sync-sanitize.test.mts
@@ -96,3 +96,36 @@ test("sanitizeDumpSqlForPreview strips heavy and sensitive member columns", asyn
   assert.equal(sanitized.sql.includes("hash"), false);
   assert.equal(sanitized.sql.includes("salt"), false);
 });
+
+test("sanitizeDumpSqlForPreview backfills empty partner campus slugs", async () => {
+  const { sanitizeDumpSqlForPreview } = await previewSyncLibPromise;
+
+  const sourceSql = [
+    "COPY public.partners (id, category_id, name, location, campus_slugs, created_at) FROM stdin;",
+    "partner-1\tcategory-1\t역삼 카페\t서울 강남구 논현로 508 1층\t{}\t2026-04-27T00:00:00.000Z",
+    "partner-2\tcategory-1\t전국 병원\t등록된 병원 전 지점\t\\N\t2026-04-27T00:00:00.000Z",
+    "partner-3\tcategory-1\t구미 카페\t경북 구미시\t{gumi}\t2026-04-27T00:00:00.000Z",
+    "\\.",
+  ].join("\n");
+
+  const previewColumnsByTable = new Map([
+    [
+      "partners",
+      new Set(["id", "category_id", "name", "location", "campus_slugs", "created_at"]),
+    ],
+  ]);
+
+  const sanitized = sanitizeDumpSqlForPreview(sourceSql, previewColumnsByTable);
+
+  assert.equal(sanitized.changed, true);
+  assert.equal(
+    sanitized.sql,
+    [
+      "COPY public.partners (id, category_id, name, location, campus_slugs, created_at) FROM stdin;",
+      "partner-1\tcategory-1\t역삼 카페\t서울 강남구 논현로 508 1층\t{seoul}\t2026-04-27T00:00:00.000Z",
+      "partner-2\tcategory-1\t전국 병원\t등록된 병원 전 지점\t{seoul,gumi,daejeon,busan-ulsan-gyeongnam,gwangju}\t2026-04-27T00:00:00.000Z",
+      "partner-3\tcategory-1\t구미 카페\t경북 구미시\t{gumi}\t2026-04-27T00:00:00.000Z",
+      "\\.",
+    ].join("\n"),
+  );
+});


### PR DESCRIPTION
## Summary
- Production 덤프의 기존 partner 행에 빈 campus_slugs가 남아 있을 때 Preview schema 제약을 통과하도록 sync sanitizer에서 보정합니다.
- location 기반 캠퍼스 추론과 전 지점/전국 문구의 전체 캠퍼스 보정을 restore 전에 적용합니다.
- 동일 실패가 재발하지 않도록 preview sync sanitizer 회귀 테스트를 추가했습니다.

## Related Issue
- 없음: dev Preview 동기화 실패에 대한 단일 CI 보정입니다.

## Branch Flow
- dev -> fix/preview-sync-campus-slugs-backfill -> dev

## Changes
- scripts/supabase-sync-preview-lib.mjs: partners COPY 블록의 campus_slugs 빈 값 보정 추가
- tests/preview-sync-sanitize.test.mts: 빈 campus_slugs backfill 회귀 테스트 추가

## Test Plan
- [x] node --import ./tests/alias-register.mjs --test tests/preview-sync-sanitize.test.mts
- [x] npx eslint scripts/supabase-sync-preview-lib.mjs tests/preview-sync-sanitize.test.mts
- [x] git diff --check
- [x] pre-push: npm test
- [x] pre-push: npm run build

## Checklist
- [x] diff 확인
- [x] Production 덤프의 빈 campus_slugs가 Preview 제약을 깨는 원인을 보정
- [x] 재발 방지 테스트 추가