### PR TITLE
refactor: 제휴 제안 폼 검증 공용화

### DIFF
--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -7,14 +7,10 @@ import {
 import { BUG_REPORT_EMAIL } from "@/lib/site";
 import { createSmtpTransport, getSmtpConfig, toSmtpConfigErrorLog } from "@/lib/smtp";
 import { isBlocked, recordAttempt, SUGGEST_RATE_LIMIT } from "@/lib/rate-limit";
-import { isValidEmail, sanitizeHttpUrl } from "@/lib/validation";
+import { validateSuggestPayload } from "@/lib/suggest-validation";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-function isEmpty(value: unknown) {
-  return !value || String(value).trim().length === 0;
-}
 
 function errorResponse(message: string, status: number, code: string) {
   return NextResponse.json({ ok: false, code, message }, { status });
@@ -52,42 +48,15 @@ export async function POST(request: Request) {
       );
     }
 
-    const payload = (await request.json()) as {
-      companyName?: string;
-      businessArea?: string;
-      partnershipConditions?: string;
-      contactName?: string;
-      contactRole?: string;
-      contactEmail?: string;
-      companyUrl?: string;
-    };
-
-    if (
-      isEmpty(payload.companyName) ||
-      isEmpty(payload.businessArea) ||
-      isEmpty(payload.partnershipConditions) ||
-      isEmpty(payload.contactName) ||
-      isEmpty(payload.contactRole) ||
-      isEmpty(payload.contactEmail)
-    ) {
-      return errorResponse("필수 항목이 누락되었습니다.", 400, "suggest_missing_required");
+    const rawPayload = (await request.json()) as Parameters<
+      typeof validateSuggestPayload
+    >[0];
+    const validation = validateSuggestPayload(rawPayload);
+    if (!validation.ok) {
+      return errorResponse(validation.message, 400, validation.code);
     }
-
-    if (!isValidEmail(payload.contactEmail)) {
-      return errorResponse("이메일 형식이 올바르지 않습니다.", 400, "suggest_invalid_email");
-    }
-
-    const safeCompanyUrlValue =
-      payload.companyUrl?.trim()
-        ? sanitizeHttpUrl(payload.companyUrl)
-        : null;
-    if (payload.companyUrl?.trim() && !safeCompanyUrlValue) {
-      return errorResponse(
-        "회사 사이트 URL 형식이 올바르지 않습니다.",
-        400,
-        "suggest_invalid_company_url",
-      );
-    }
+    const payload = validation.values;
+    const safeCompanyUrlValue = validation.safeCompanyUrl;
 
     await recordAttempt(identifier, false, SUGGEST_RATE_LIMIT);
 

--- a/src/components/SuggestForm.tsx
+++ b/src/components/SuggestForm.tsx
@@ -8,67 +8,16 @@ import InlineMessage from "@/components/ui/InlineMessage";
 import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import Modal from "@/components/ui/Modal";
-import { sanitizeHttpUrl } from "@/lib/validation";
-
-const initialState = {
-  companyName: "",
-  businessArea: "",
-  partnershipConditions: "",
-  contactName: "",
-  contactRole: "",
-  contactEmail: "",
-  companyUrl: "",
-};
-
-type SuggestFormState = typeof initialState;
-type SuggestFieldName = keyof SuggestFormState;
-type SuggestFieldErrors = Partial<Record<SuggestFieldName, string>>;
-
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const requiredFieldLabels: Record<Exclude<SuggestFieldName, "companyUrl">, string> = {
-  companyName: "업체명을 입력해 주세요.",
-  businessArea: "업체 분야 소개를 입력해 주세요.",
-  partnershipConditions: "제안 제휴 조건을 입력해 주세요.",
-  contactName: "담당자 이름을 입력해 주세요.",
-  contactRole: "담당자 직위를 입력해 주세요.",
-  contactEmail: "담당자 이메일을 입력해 주세요.",
-};
-
-const fieldOrder: SuggestFieldName[] = [
-  "companyName",
-  "businessArea",
-  "partnershipConditions",
-  "companyUrl",
-  "contactName",
-  "contactRole",
-  "contactEmail",
-];
+import {
+  SUGGEST_FIELD_ORDER,
+  suggestFormInitialState,
+  type SuggestFieldErrors,
+  type SuggestFieldName,
+  validateSuggestForm,
+} from "@/lib/suggest-validation";
 
 const invalidFieldClassName =
   "border-danger/50 bg-danger/5 focus:border-danger focus:ring-danger/15";
-
-function validateSuggestForm(values: SuggestFormState): SuggestFieldErrors {
-  const errors: SuggestFieldErrors = {};
-
-  for (const [fieldName, message] of Object.entries(requiredFieldLabels) as [
-    Exclude<SuggestFieldName, "companyUrl">,
-    string,
-  ][]) {
-    if (!values[fieldName].trim()) {
-      errors[fieldName] = message;
-    }
-  }
-
-  if (values.contactEmail.trim() && !emailRegex.test(values.contactEmail.trim())) {
-    errors.contactEmail = "이메일 형식을 확인해 주세요.";
-  }
-
-  if (values.companyUrl.trim() && !sanitizeHttpUrl(values.companyUrl)) {
-    errors.companyUrl = "회사 사이트 URL 형식을 확인해 주세요.";
-  }
-
-  return errors;
-}
 
 function SuggestField({
   label,
@@ -111,7 +60,7 @@ function SuggestField({
 }
 
 export default function SuggestForm() {
-  const [formState, setFormState] = useState(initialState);
+  const [formState, setFormState] = useState(suggestFormInitialState);
   const [isSubmitting, setSubmitting] = useState(false);
   const [isConfirmOpen, setConfirmOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -188,7 +137,7 @@ export default function SuggestForm() {
         const nextFieldErrors = validateSuggestForm(formState);
         setFieldErrors(nextFieldErrors);
 
-        const firstInvalidField = fieldOrder.find(
+        const firstInvalidField = SUGGEST_FIELD_ORDER.find(
           (fieldName) => nextFieldErrors[fieldName],
         );
         if (firstInvalidField) {

--- a/src/lib/suggest-validation.ts
+++ b/src/lib/suggest-validation.ts
@@ -1,0 +1,146 @@
+import { isValidEmail, sanitizeHttpUrl } from "@/lib/validation";
+
+export const suggestFormInitialState = {
+  companyName: "",
+  businessArea: "",
+  partnershipConditions: "",
+  contactName: "",
+  contactRole: "",
+  contactEmail: "",
+  companyUrl: "",
+};
+
+export type SuggestFormState = typeof suggestFormInitialState;
+export type SuggestFieldName = keyof SuggestFormState;
+export type SuggestFieldErrors = Partial<Record<SuggestFieldName, string>>;
+
+export type SuggestValidationErrorCode =
+  | "suggest_missing_required"
+  | "suggest_invalid_email"
+  | "suggest_invalid_company_url";
+
+export const SUGGEST_FIELD_ORDER: SuggestFieldName[] = [
+  "companyName",
+  "businessArea",
+  "partnershipConditions",
+  "companyUrl",
+  "contactName",
+  "contactRole",
+  "contactEmail",
+];
+
+const requiredFieldMessages: Record<Exclude<SuggestFieldName, "companyUrl">, string> = {
+  companyName: "업체명을 입력해 주세요.",
+  businessArea: "업체 분야 소개를 입력해 주세요.",
+  partnershipConditions: "제안 제휴 조건을 입력해 주세요.",
+  contactName: "담당자 이름을 입력해 주세요.",
+  contactRole: "담당자 직위를 입력해 주세요.",
+  contactEmail: "담당자 이메일을 입력해 주세요.",
+};
+
+const validationMessages: Record<SuggestValidationErrorCode, string> = {
+  suggest_missing_required: "필수 항목이 누락되었습니다.",
+  suggest_invalid_email: "이메일 형식이 올바르지 않습니다.",
+  suggest_invalid_company_url: "회사 사이트 URL 형식이 올바르지 않습니다.",
+};
+
+function normalizeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function normalizeSuggestFormInput(
+  input: Partial<Record<SuggestFieldName, unknown>> | null | undefined,
+): SuggestFormState {
+  const source = input ?? {};
+  return {
+    companyName: normalizeString(source.companyName),
+    businessArea: normalizeString(source.businessArea),
+    partnershipConditions: normalizeString(source.partnershipConditions),
+    contactName: normalizeString(source.contactName),
+    contactRole: normalizeString(source.contactRole),
+    contactEmail: normalizeString(source.contactEmail),
+    companyUrl: normalizeString(source.companyUrl),
+  };
+}
+
+export function validateSuggestForm(values: SuggestFormState): SuggestFieldErrors {
+  const normalized = normalizeSuggestFormInput(values);
+  const errors: SuggestFieldErrors = {};
+
+  for (const [fieldName, message] of Object.entries(requiredFieldMessages) as [
+    Exclude<SuggestFieldName, "companyUrl">,
+    string,
+  ][]) {
+    if (!normalized[fieldName]) {
+      errors[fieldName] = message;
+    }
+  }
+
+  if (normalized.contactEmail && !isValidEmail(normalized.contactEmail)) {
+    errors.contactEmail = "이메일 형식을 확인해 주세요.";
+  }
+
+  if (normalized.companyUrl && !sanitizeHttpUrl(normalized.companyUrl)) {
+    errors.companyUrl = "회사 사이트 URL 형식을 확인해 주세요.";
+  }
+
+  return errors;
+}
+
+export function getSuggestValidationErrorCode(
+  errors: SuggestFieldErrors,
+): SuggestValidationErrorCode | null {
+  const hasMissingRequired = Object.entries(requiredFieldMessages).some(
+    ([fieldName, message]) => errors[fieldName as SuggestFieldName] === message,
+  );
+  if (hasMissingRequired) {
+    return "suggest_missing_required";
+  }
+  if (errors.contactEmail) {
+    return "suggest_invalid_email";
+  }
+  if (errors.companyUrl) {
+    return "suggest_invalid_company_url";
+  }
+  return null;
+}
+
+export function getSuggestValidationMessage(code: SuggestValidationErrorCode) {
+  return validationMessages[code];
+}
+
+export function validateSuggestPayload(
+  input: Partial<Record<SuggestFieldName, unknown>> | null | undefined,
+):
+  | {
+      ok: true;
+      values: SuggestFormState;
+      safeCompanyUrl: string | null;
+    }
+  | {
+      ok: false;
+      values: SuggestFormState;
+      fieldErrors: SuggestFieldErrors;
+      code: SuggestValidationErrorCode;
+      message: string;
+    } {
+  const values = normalizeSuggestFormInput(input);
+  const fieldErrors = validateSuggestForm(values);
+  const code = getSuggestValidationErrorCode(fieldErrors);
+
+  if (code) {
+    return {
+      ok: false,
+      values,
+      fieldErrors,
+      code,
+      message: getSuggestValidationMessage(code),
+    };
+  }
+
+  return {
+    ok: true,
+    values,
+    safeCompanyUrl: values.companyUrl ? sanitizeHttpUrl(values.companyUrl) : null,
+  };
+}

--- a/tests/suggest-validation.test.mts
+++ b/tests/suggest-validation.test.mts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type SuggestValidationModule = typeof import("../src/lib/suggest-validation.ts");
+
+const suggestValidationPromise = import(
+  new URL("../src/lib/suggest-validation.ts", import.meta.url).href,
+) as Promise<SuggestValidationModule>;
+
+const validInput = {
+  companyName: "싸트너십 카페",
+  businessArea: "역삼역 인근 베이커리 카페",
+  partnershipConditions: "SSAFY 인증 화면 제시 시 전 메뉴 10% 할인",
+  contactName: "김담당",
+  contactRole: "매니저",
+  contactEmail: "manager@example.com",
+  companyUrl: "https://example.com",
+};
+
+test("suggest validation rejects missing required fields with field errors", async () => {
+  const { validateSuggestPayload } = await suggestValidationPromise;
+
+  const result = validateSuggestPayload({
+    ...validInput,
+    companyName: " ",
+    contactEmail: "",
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "suggest_missing_required");
+    assert.equal(result.message, "필수 항목이 누락되었습니다.");
+    assert.equal(result.fieldErrors.companyName, "업체명을 입력해 주세요.");
+    assert.equal(result.fieldErrors.contactEmail, "담당자 이메일을 입력해 주세요.");
+  }
+});
+
+test("suggest validation rejects non-object payloads as missing required fields", async () => {
+  const { validateSuggestPayload } = await suggestValidationPromise;
+
+  const result = validateSuggestPayload(null);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "suggest_missing_required");
+    assert.equal(result.fieldErrors.companyName, "업체명을 입력해 주세요.");
+  }
+});
+
+test("suggest validation rejects invalid contact email", async () => {
+  const { validateSuggestPayload } = await suggestValidationPromise;
+
+  const result = validateSuggestPayload({
+    ...validInput,
+    contactEmail: "not-an-email",
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "suggest_invalid_email");
+    assert.equal(result.message, "이메일 형식이 올바르지 않습니다.");
+    assert.equal(result.fieldErrors.contactEmail, "이메일 형식을 확인해 주세요.");
+  }
+});
+
+test("suggest validation rejects unsafe company URL", async () => {
+  const { validateSuggestPayload } = await suggestValidationPromise;
+
+  const result = validateSuggestPayload({
+    ...validInput,
+    companyUrl: "javascript:alert(1)",
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "suggest_invalid_company_url");
+    assert.equal(result.message, "회사 사이트 URL 형식이 올바르지 않습니다.");
+    assert.equal(result.fieldErrors.companyUrl, "회사 사이트 URL 형식을 확인해 주세요.");
+  }
+});
+
+test("suggest validation normalizes valid input and sanitizes company URL", async () => {
+  const { validateSuggestPayload } = await suggestValidationPromise;
+
+  const result = validateSuggestPayload({
+    ...validInput,
+    companyName: "  싸트너십 카페  ",
+    companyUrl: " https://example.com/partner ",
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.values.companyName, "싸트너십 카페");
+    assert.equal(result.safeCompanyUrl, "https://example.com/partner");
+  }
+});


### PR DESCRIPTION
## Summary
- 제휴 제안 폼의 FE/BE 중복 validation을 공용 helper로 분리했습니다.
- 클라이언트 submit 사전 차단과 /api/suggest 서버 경계가 동일한 필수값, 이메일, URL 규칙을 사용합니다.
- null/non-object payload도 서버 검증에서 안전하게 필수값 오류로 처리합니다.

## Related Issue
Refs #15

## Branch Flow
- base: dev
- head: refactor/shared-form-validation

## Changes
- src/lib/suggest-validation.ts 공용 validation helper 추가
- src/components/SuggestForm.tsx에서 공용 helper 기반 필드 오류/focus 처리 사용
- src/app/api/suggest/route.ts에서 동일 helper로 request payload 검증
- tests/suggest-validation.test.mts 단위 테스트 추가

## Test Plan
- [x] node --import ./tests/alias-register.mjs --test tests/suggest-validation.test.mts
- [x] npx eslint src/lib/suggest-validation.ts src/components/SuggestForm.tsx src/app/api/suggest/route.ts tests/suggest-validation.test.mts
- [x] npm run release 과정의 build-storybook/test-storybook 통과
- [!] npx tsc --noEmit --pretty false 실행 시 기존 테스트 타입 오류로 실패: partner-counts, partner-setup-fallback, smtp-config, policy-documents 테스트 타입 이슈

## Checklist
- [x] FE 검증은 UX용 사전 차단으로 유지
- [x] BE 검증은 API 신뢰 경계에서 동일 규칙으로 유지
- [x] PR은 dev 대상으로 생성
