### PR TITLE
feat: 혜택 공개 범위 분리

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -20,6 +20,7 @@ import { buildSiteUrl, createCanonicalAlternates } from "@/lib/seo";
 import { getHeaderSession } from "@/lib/header-session";
 import { getSignedUserSession } from "@/lib/user-auth";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { resolvePartnerAudienceFromMemberYear } from "@/lib/partner-audience";
 
 export const revalidate = 300;
 
@@ -127,6 +128,9 @@ export default async function Home() {
             <HomeContent
               viewerAuthenticated={Boolean(session?.userId)}
               currentUserId={session?.userId ?? null}
+              viewerAudience={resolvePartnerAudienceFromMemberYear(
+                typeof member?.year === "number" ? member.year : null,
+              )}
             />
           </Suspense>
         </Container>

--- a/src/app/(site)/partners/[id]/_page/page-data.ts
+++ b/src/app/(site)/partners/[id]/_page/page-data.ts
@@ -22,11 +22,20 @@ import {
 } from "@/lib/seo/partners";
 import type { PartnerPortalServiceMetrics } from "@/lib/partner-dashboard";
 import type { Category, Partner } from "@/lib/types";
+import type { PartnerAudienceKey } from "@/lib/partner-audience";
 
 const getCategoriesCached = cache(async () => partnerRepository.getCategories());
 
-const getPartnerByIdCached = cache(async (id: string, authenticated: boolean) =>
-  partnerRepository.getPartnerById(id, { authenticated }),
+const getPartnerByIdCached = cache(
+  async (
+    id: string,
+    authenticated: boolean,
+    viewerAudience?: PartnerAudienceKey | null,
+  ) =>
+    partnerRepository.getPartnerById(id, {
+      authenticated,
+      viewerAudience,
+    }),
 );
 
 const getPartnerByIdRawCached = cache(async (id: string) =>
@@ -122,10 +131,11 @@ export async function getPartnerDetailPageData(
   rawId: string,
   authenticated: boolean,
   currentUserId?: string | null,
+  viewerAudience?: PartnerAudienceKey | null,
 ): Promise<PartnerDetailPageData | PartnerDetailAccessGateData | null> {
   const [categories, partner, favoriteIds] = await Promise.all([
     getCategoriesCached(),
-    getPartnerByIdCached(rawId, authenticated),
+    getPartnerByIdCached(rawId, authenticated, viewerAudience),
     currentUserId ? partnerFavoriteRepository.getMemberFavoritePartnerIds(currentUserId, [rawId]) : Promise.resolve(new Set<string>()),
   ]);
 

--- a/src/app/(site)/partners/[id]/page.tsx
+++ b/src/app/(site)/partners/[id]/page.tsx
@@ -9,6 +9,8 @@ import PartnerImageCarousel from "@/components/PartnerImageCarousel";
 import ShareLinkButton from "@/components/ShareLinkButton";
 import { SITE_NAME } from "@/lib/site";
 import { createCanonicalAlternates } from "@/lib/seo";
+import { resolvePartnerAudienceFromMemberYear } from "@/lib/partner-audience";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import PartnerDetailContactSection from "./_page/PartnerDetailContactSection";
 import PartnerDetailAccessGate from "./_page/PartnerDetailAccessGate";
 import { getPartnerDetailPageData, getPartnerMetadataData } from "./_page/page-data";
@@ -104,10 +106,21 @@ export default async function PartnerDetailPage({
   if (!rawId) {
     redirect("/");
   }
+  const member = headerSession?.userId
+    ? await getSupabaseAdminClient()
+        .from("members")
+        .select("year")
+        .eq("id", headerSession.userId)
+        .maybeSingle()
+        .then(({ data }) => data)
+    : null;
   const pageData = await getPartnerDetailPageData(
     rawId,
     Boolean(headerSession?.userId),
     headerSession?.userId ?? null,
+    resolvePartnerAudienceFromMemberYear(
+      typeof member?.year === "number" ? member.year : null,
+    ),
   );
   if (!pageData) {
     redirect("/");

--- a/src/app/admin/(protected)/_actions/partner-actions/create.ts
+++ b/src/app/admin/(protected)/_actions/partner-actions/create.ts
@@ -56,6 +56,7 @@ async function createPartnerRecord(formData: FormData): Promise<CreatedPartnerRe
       images: media.images,
       tags: payload.tags,
       visibility: payload.visibility,
+      benefit_visibility: payload.benefitVisibility,
     });
 
     if (error) {
@@ -96,6 +97,7 @@ async function finalizeCreatedPartner(record: CreatedPartnerRecord) {
       periodEnd: payload.periodEnd,
       conditionCount: payload.conditions.length,
       visibility: payload.visibility,
+      benefitVisibility: payload.benefitVisibility,
       benefitCount: payload.benefits.length,
       appliesTo: payload.appliesTo,
       hasThumbnail: Boolean(media.thumbnail),

--- a/src/app/admin/(protected)/_actions/partner-actions/update.ts
+++ b/src/app/admin/(protected)/_actions/partner-actions/update.ts
@@ -51,7 +51,7 @@ export async function updatePartnerAction(formData: FormData) {
   const { data: previousPartner, error: previousPartnerError } = await supabase
     .from("partners")
     .select(
-      "company_id,category_id,name,location,campus_slugs,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,thumbnail,images,tags,visibility,company:partner_companies(id,name,slug),categories(id,label)",
+      "company_id,category_id,name,location,campus_slugs,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,thumbnail,images,tags,visibility,benefit_visibility,company:partner_companies(id,name,slug),categories(id,label)",
     )
     .eq("id", id)
     .maybeSingle();
@@ -143,6 +143,7 @@ export async function updatePartnerAction(formData: FormData) {
         images: media.images,
         tags: payload.tags,
         visibility: payload.visibility,
+        benefit_visibility: payload.benefitVisibility,
       })
       .eq("id", id);
 
@@ -270,6 +271,11 @@ export async function updatePartnerAction(formData: FormData) {
       before: previousPartner.visibility,
       after: payload.visibility,
     },
+    {
+      label: "혜택 공개 범위",
+      before: previousPartner.benefit_visibility ?? "public",
+      after: payload.benefitVisibility,
+    },
   ]);
 
   if (partnerAudit.changedFields.length > 0) {
@@ -284,6 +290,7 @@ export async function updatePartnerAction(formData: FormData) {
         companyName: nextCompanyLabel,
         categoryLabel: nextCategoryLabel,
         visibility: payload.visibility,
+        benefitVisibility: payload.benefitVisibility,
       },
     });
   }

--- a/src/app/admin/(protected)/_actions/shared-parsers.ts
+++ b/src/app/admin/(protected)/_actions/shared-parsers.ts
@@ -4,6 +4,10 @@ import {
   normalizePartnerVisibility,
 } from "../../../../lib/partner-visibility.ts";
 import { parsePartnerAudienceSelection } from "../../../../lib/partner-audience.ts";
+import {
+  isPartnerBenefitVisibility,
+  normalizePartnerBenefitVisibility,
+} from "../../../../lib/partner-benefit-visibility.ts";
 import { normalizePartnerLoginId } from "../../../../lib/partner-utils.ts";
 import {
   isValidEmail,
@@ -228,6 +232,7 @@ export function parsePartnerPayload(formData: FormData): PartnerCoreInput {
   const rawReservationLink = String(formData.get("reservationLink") || "").trim();
   const rawInquiryLink = String(formData.get("inquiryLink") || "").trim();
   const rawVisibility = String(formData.get("visibility") || "").trim();
+  const rawBenefitVisibility = String(formData.get("benefitVisibility") || "").trim();
   const periodStart = String(formData.get("periodStart") || "").trim();
   const periodEnd = String(formData.get("periodEnd") || "").trim();
   const conditions = String(formData.get("conditions") || "").trim();
@@ -272,6 +277,9 @@ export function parsePartnerPayload(formData: FormData): PartnerCoreInput {
   if (rawVisibility && !isPartnerVisibility(rawVisibility)) {
     throw new Error("partner_form_invalid_visibility");
   }
+  if (rawBenefitVisibility && !isPartnerBenefitVisibility(rawBenefitVisibility)) {
+    throw new Error("partner_form_invalid_benefit_visibility");
+  }
 
   const parsedAppliesTo = parsePartnerAudienceSelection(appliesTo);
   if (!parsedAppliesTo) {
@@ -296,5 +304,8 @@ export function parsePartnerPayload(formData: FormData): PartnerCoreInput {
     appliesTo: parsedAppliesTo,
     tags: parseList(tags),
     visibility: normalizePartnerVisibility(rawVisibility || "public"),
+    benefitVisibility: normalizePartnerBenefitVisibility(
+      rawBenefitVisibility || "public",
+    ),
   };
 }

--- a/src/app/admin/(protected)/_actions/shared-types.ts
+++ b/src/app/admin/(protected)/_actions/shared-types.ts
@@ -1,4 +1,5 @@
 import type { CampusSlug } from "../../../../lib/campuses.ts";
+import type { PartnerBenefitVisibility } from "../../../../lib/partner-benefit-visibility.ts";
 import type { PartnerVisibility } from "../../../../lib/types.ts";
 
 export type AdminSupabaseClient = ReturnType<typeof import("@/lib/supabase/server").getSupabaseAdminClient>;
@@ -18,6 +19,7 @@ export type PartnerCoreInput = {
   appliesTo: string[];
   tags: string[];
   visibility: PartnerVisibility;
+  benefitVisibility: PartnerBenefitVisibility;
 };
 
 export type PartnerMediaInput = {

--- a/src/app/admin/(protected)/partners/[partnerId]/page.tsx
+++ b/src/app/admin/(protected)/partners/[partnerId]/page.tsx
@@ -100,7 +100,7 @@ export default async function AdminPartnerDetailPage({
     supabase
       .from("partners")
       .select(
-        "id,created_at,name,category_id,company_id,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,company:partner_companies(id,name,slug,description,is_active),categories(id,key,label,color,description)",
+        "id,created_at,name,category_id,company_id,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,benefit_visibility,company:partner_companies(id,name,slug,description,is_active),categories(id,key,label,color,description)",
       )
       .eq("id", partnerId)
       .maybeSingle(),
@@ -283,6 +283,7 @@ export default async function AdminPartnerDetailPage({
                   id: partner.id,
                   name: partner.name ?? "",
                   visibility: partner.visibility,
+                  benefitVisibility: partner.benefit_visibility ?? "public",
                   location: partner.location ?? "",
                   campusSlugs: partner.campus_slugs ?? [],
                   mapUrl: partner.map_url ?? "",

--- a/src/app/admin/(protected)/partners/new/page.tsx
+++ b/src/app/admin/(protected)/partners/new/page.tsx
@@ -91,6 +91,7 @@ export default async function AdminPartnerNewPage() {
                 partner={{
                   name: "",
                   visibility: "public",
+                  benefitVisibility: "public",
                   location: "",
                   campusSlugs: ["seoul", "gumi", "daejeon", "busan-ulsan-gyeongnam", "gwangju"],
                   mapUrl: "",

--- a/src/app/admin/(protected)/partners/page.tsx
+++ b/src/app/admin/(protected)/partners/page.tsx
@@ -71,7 +71,7 @@ export default async function AdminPartnersPage({
       .order("created_at", { ascending: true }),
     supabase
       .from("partners")
-      .select("id,name,category_id,company_id,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,company:partner_companies(id,name,slug,description,is_active)")
+      .select("id,name,category_id,company_id,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,benefit_visibility,company:partner_companies(id,name,slug,description,is_active)")
       .order("created_at", { ascending: false }),
     listPartnerChangeRequests(),
   ]);

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -3,18 +3,22 @@ import { getAdminPartnerMetrics } from "@/lib/admin-partner-metrics";
 import { partnerFavoriteRepository, partnerRepository } from "@/lib/repositories";
 import { isWithinPeriod } from "@/lib/partner-utils";
 import type { PartnerPopularityMetrics } from "@/lib/partner-popularity";
+import type { PartnerAudienceKey } from "@/lib/partner-audience";
 
 export default async function HomeContent({
   viewerAuthenticated,
   currentUserId,
+  viewerAudience,
 }: {
   viewerAuthenticated: boolean;
   currentUserId: string | null;
+  viewerAudience?: PartnerAudienceKey | null;
 }) {
   const [categories, partners] = await Promise.all([
     partnerRepository.getCategories(),
     partnerRepository.getPartners({
       authenticated: viewerAuthenticated,
+      viewerAudience,
     }),
   ]);
 

--- a/src/components/admin/AdminPartnerCreateForm.tsx
+++ b/src/components/admin/AdminPartnerCreateForm.tsx
@@ -25,6 +25,7 @@ const partnerFormFocusByError: Record<string, PartnerCardFormField> = {
   partner_form_invalid_reservation_url: "reservationLink",
   partner_form_invalid_inquiry_url: "inquiryLink",
   partner_form_invalid_visibility: "visibility",
+  partner_form_invalid_benefit_visibility: "benefitVisibility",
   partner_form_invalid_applies_to: "appliesTo",
   partner_company_missing_name: "companyName",
   partner_company_missing_email: "companyContactEmail",

--- a/src/components/admin/partner-manager/types.ts
+++ b/src/components/admin/partner-manager/types.ts
@@ -1,4 +1,5 @@
 import type { CategoryKey } from "@/lib/types";
+import type { PartnerBenefitVisibility } from "@/lib/partner-benefit-visibility";
 import type { PartnerPortalServiceMetrics } from "@/lib/partner-dashboard";
 
 export type AdminCategory = {
@@ -15,6 +16,7 @@ export type AdminPartner = {
   category_id: string;
   company_id?: string | null;
   visibility: "public" | "confidential" | "private";
+  benefit_visibility?: PartnerBenefitVisibility | null;
   location: string;
   map_url?: string | null;
   reservation_link?: string | null;

--- a/src/components/partner-card-form/PartnerBasicInfoSection.tsx
+++ b/src/components/partner-card-form/PartnerBasicInfoSection.tsx
@@ -1,4 +1,5 @@
 import type { PartnerVisibility } from "@/lib/types";
+import type { PartnerBenefitVisibility } from "@/lib/partner-benefit-visibility";
 import type { CampusSlug } from "@/lib/campuses";
 import Card from "@/components/ui/Card";
 import Input from "@/components/ui/Input";
@@ -34,6 +35,7 @@ export default function PartnerBasicInfoSection({
   values: {
     nameValue: string;
     visibilityValue: PartnerVisibility;
+    benefitVisibilityValue: PartnerBenefitVisibility;
     categoryValue: string;
     periodStartValue: string;
     periodEndValue: string;
@@ -45,6 +47,7 @@ export default function PartnerBasicInfoSection({
   setters: {
     setNameValue: (value: string) => void;
     setVisibilityValue: (value: PartnerVisibility) => void;
+    setBenefitVisibilityValue: (value: PartnerBenefitVisibility) => void;
     setCategoryValue: (value: string) => void;
     setPeriodStartValue: (value: string) => void;
     setPeriodEndValue: (value: string) => void;
@@ -95,6 +98,27 @@ export default function PartnerBasicInfoSection({
               <option value="private">비공개</option>
             </Select>
           </FieldGroup>
+          <FieldGroup label="혜택 공개 범위" error={fieldErrors?.benefitVisibility}>
+            <Select
+              name="benefitVisibility"
+              value={values.benefitVisibilityValue}
+              onChange={(event) =>
+                setters.setBenefitVisibilityValue(
+                  event.target.value as PartnerBenefitVisibility,
+                )
+              }
+              required
+              autoFocus={focusField === "benefitVisibility"}
+              aria-invalid={Boolean(fieldErrors?.benefitVisibility) || undefined}
+              className={getPartnerCardInvalidClass(Boolean(fieldErrors?.benefitVisibility))}
+            >
+              <option value="public">혜택 전체 공개</option>
+              <option value="eligible_only">혜택 대상자만 공개</option>
+            </Select>
+          </FieldGroup>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
           <FieldGroup label="카테고리" error={fieldErrors?.categoryId}>
             <Select
               name="categoryId"

--- a/src/components/partner-card-form/PartnerCardForm.tsx
+++ b/src/components/partner-card-form/PartnerCardForm.tsx
@@ -62,6 +62,8 @@ export default function PartnerCardForm({
     setNameValue,
     visibilityValue,
     setVisibilityValue,
+    benefitVisibilityValue,
+    setBenefitVisibilityValue,
     categoryValue,
     setCategoryValue,
     periodStartValue,
@@ -172,6 +174,7 @@ export default function PartnerCardForm({
             values={{
               nameValue,
               visibilityValue,
+              benefitVisibilityValue,
               categoryValue,
               periodStartValue,
               periodEndValue,
@@ -183,6 +186,7 @@ export default function PartnerCardForm({
             setters={{
               setNameValue,
               setVisibilityValue: (value) => setVisibilityValue(value),
+              setBenefitVisibilityValue,
               setCategoryValue,
               setPeriodStartValue,
               setPeriodEndValue,

--- a/src/components/partner-card-form/types.ts
+++ b/src/components/partner-card-form/types.ts
@@ -1,4 +1,5 @@
 import type { PartnerVisibility } from "@/lib/types";
+import type { PartnerBenefitVisibility } from "@/lib/partner-benefit-visibility";
 import type { CampusSlug } from "@/lib/campuses";
 import type { PartnerFormField } from "@/lib/partner-form-state";
 
@@ -26,6 +27,7 @@ export type PartnerCardFormValues = {
   id?: string;
   name?: string;
   visibility?: PartnerVisibility;
+  benefitVisibility?: PartnerBenefitVisibility;
   location?: string;
   campusSlugs?: CampusSlug[];
   mapUrl?: string;

--- a/src/components/partner-card-form/usePartnerCardFormState.ts
+++ b/src/components/partner-card-form/usePartnerCardFormState.ts
@@ -28,6 +28,7 @@ export function createPartnerCardFormState(
     selectedCompanyId: partner.company?.id ?? "",
     nameValue: partner.name ?? "",
     visibilityValue: partner.visibility ?? "public",
+    benefitVisibilityValue: partner.benefitVisibility ?? "public",
     categoryValue: categoryId ?? "",
     locationValue: partner.location ?? "",
     mapUrlValue: partner.mapUrl ?? "",
@@ -58,6 +59,9 @@ export default function usePartnerCardFormState({
   const [selectedCompanyId, setSelectedCompanyId] = useState(defaults.selectedCompanyId);
   const [nameValue, setNameValue] = useState(defaults.nameValue);
   const [visibilityValue, setVisibilityValue] = useState(defaults.visibilityValue);
+  const [benefitVisibilityValue, setBenefitVisibilityValue] = useState(
+    defaults.benefitVisibilityValue,
+  );
   const [categoryValue, setCategoryValue] = useState(defaults.categoryValue);
   const [periodStartValue, setPeriodStartValue] = useState(defaults.periodStart);
   const [periodEndValue, setPeriodEndValue] = useState(defaults.periodEnd);
@@ -100,6 +104,8 @@ export default function usePartnerCardFormState({
     setNameValue,
     visibilityValue,
     setVisibilityValue,
+    benefitVisibilityValue,
+    setBenefitVisibilityValue,
     categoryValue,
     setCategoryValue,
     periodStartValue,

--- a/src/lib/partner-audience.ts
+++ b/src/lib/partner-audience.ts
@@ -90,3 +90,14 @@ export function getPartnerAudienceLabel(value: PartnerAudienceKey) {
   return PARTNER_AUDIENCE_LABEL_MAP[value];
 }
 
+export function resolvePartnerAudienceFromMemberYear(
+  year?: number | null,
+): PartnerAudienceKey | null {
+  if (typeof year !== "number") {
+    return null;
+  }
+  if (year === 0) {
+    return "staff";
+  }
+  return year >= 14 ? "student" : "graduate";
+}

--- a/src/lib/partner-benefit-visibility.ts
+++ b/src/lib/partner-benefit-visibility.ts
@@ -1,0 +1,72 @@
+import type { PartnerAudienceKey } from "@/lib/partner-audience";
+import type { Partner } from "@/lib/types";
+
+export type PartnerBenefitVisibility = "public" | "eligible_only";
+
+export type PartnerBenefitAccessContext = {
+  authenticated: boolean;
+  viewerAudience?: PartnerAudienceKey | null;
+};
+
+export const BENEFIT_LOGIN_REQUIRED_MESSAGE = "로그인 후 조회 가능합니다.";
+export const BENEFIT_ELIGIBLE_ONLY_MESSAGE = "혜택 대상자만 조회 가능합니다.";
+
+export function isPartnerBenefitVisibility(
+  value: string,
+): value is PartnerBenefitVisibility {
+  return value === "public" || value === "eligible_only";
+}
+
+export function normalizePartnerBenefitVisibility(
+  value?: string | null,
+): PartnerBenefitVisibility {
+  const normalized = value ?? "";
+  return isPartnerBenefitVisibility(normalized) ? normalized : "public";
+}
+
+export function getPartnerBenefitAccessMessage(
+  visibility: PartnerBenefitVisibility,
+  context: PartnerBenefitAccessContext,
+  appliesTo: PartnerAudienceKey[],
+) {
+  if (visibility === "public") {
+    return null;
+  }
+  if (!context.authenticated) {
+    return BENEFIT_LOGIN_REQUIRED_MESSAGE;
+  }
+  if (!context.viewerAudience || !appliesTo.includes(context.viewerAudience)) {
+    return BENEFIT_ELIGIBLE_ONLY_MESSAGE;
+  }
+  return null;
+}
+
+export function canViewPartnerBenefits(
+  visibility: PartnerBenefitVisibility,
+  context: PartnerBenefitAccessContext,
+  appliesTo: PartnerAudienceKey[],
+) {
+  return getPartnerBenefitAccessMessage(visibility, context, appliesTo) === null;
+}
+
+export function maskPartnerBenefitsForAccess(
+  partner: Partner,
+  context: PartnerBenefitAccessContext,
+): Partner {
+  const accessMessage = getPartnerBenefitAccessMessage(
+    normalizePartnerBenefitVisibility(partner.benefitVisibility),
+    context,
+    partner.appliesTo,
+  );
+
+  if (!accessMessage) {
+    return partner;
+  }
+
+  return {
+    ...partner,
+    reservationLink: undefined,
+    conditions: [accessMessage],
+    benefits: [accessMessage],
+  };
+}

--- a/src/lib/partner-form-errors.ts
+++ b/src/lib/partner-form-errors.ts
@@ -9,6 +9,8 @@ export const partnerFormErrorMessages: Record<string, string> = {
   partner_form_invalid_reservation_url: "예약 링크 형식을 확인해 주세요.",
   partner_form_invalid_inquiry_url: "문의 링크 형식을 확인해 주세요.",
   partner_form_invalid_visibility: "노출 상태는 공개, 대외비, 비공개 중 하나여야 합니다.",
+  partner_form_invalid_benefit_visibility:
+    "혜택 공개 범위는 전체 공개 또는 대상자 공개 중 하나여야 합니다.",
   partner_form_invalid_applies_to: "적용 대상을 하나 이상 선택해 주세요.",
   partner_form_invalid_request: "입력값을 확인해 주세요.",
   partner_company_missing_name: "협력사명을 입력해 주세요.",

--- a/src/lib/partner-form-state.ts
+++ b/src/lib/partner-form-state.ts
@@ -9,6 +9,7 @@ export type PartnerFormField =
   | "reservationLink"
   | "inquiryLink"
   | "visibility"
+  | "benefitVisibility"
   | "companyId"
   | "companyName"
   | "companyContactName"

--- a/src/lib/repositories/mock/partner-repository.mock.ts
+++ b/src/lib/repositories/mock/partner-repository.mock.ts
@@ -1,6 +1,7 @@
 import type { Category, Partner } from "@/lib/types";
 import type { PartnerRepository } from "@/lib/repositories/partner-repository";
 import { canViewPartnerDetails } from "@/lib/partner-visibility";
+import { maskPartnerBenefitsForAccess } from "@/lib/partner-benefit-visibility";
 
 const categories: Category[] = [
   {
@@ -35,6 +36,7 @@ const partners: Partner[] = [
     name: "바디라인 피트니스",
     category: "health",
     visibility: "public",
+    benefitVisibility: "eligible_only",
     createdAt: "2026-03-01T00:00:00.000Z",
     location: "서울 강남구 테헤란로 123, 4층",
     campusSlugs: ["seoul"],
@@ -54,6 +56,7 @@ const partners: Partner[] = [
     name: "역삼 국밥집",
     category: "restaurant",
     visibility: "confidential",
+    benefitVisibility: "public",
     createdAt: "2026-03-10T00:00:00.000Z",
     location: "서울 강남구 역삼로 45",
     campusSlugs: ["seoul"],
@@ -73,6 +76,7 @@ const partners: Partner[] = [
     name: "노트북 허브 카페",
     category: "cafe",
     visibility: "private",
+    benefitVisibility: "public",
     createdAt: "2026-02-15T00:00:00.000Z",
     location: "서울 강남구 봉은사로 12",
     campusSlugs: ["seoul"],
@@ -92,6 +96,7 @@ const partners: Partner[] = [
     name: "협업 스테이션",
     category: "space",
     visibility: "public",
+    benefitVisibility: "public",
     createdAt: "2026-01-01T00:00:00.000Z",
     location: "서울 강남구 언주로 88, 7층",
     campusSlugs: ["seoul"],
@@ -116,13 +121,14 @@ export class MockPartnerRepository implements PartnerRepository {
   async getPartners(context: { authenticated: boolean } = { authenticated: false }): Promise<Partner[]> {
     return partners.map((partner) => {
       if (canViewPartnerDetails(partner.visibility, context.authenticated)) {
-        return partner;
+        return maskPartnerBenefitsForAccess(partner, context);
       }
       return {
         id: partner.id,
         name: "",
         category: partner.category,
         visibility: partner.visibility,
+        benefitVisibility: partner.benefitVisibility,
         createdAt: partner.createdAt,
         location: "",
         campusSlugs: partner.campusSlugs,
@@ -153,7 +159,7 @@ export class MockPartnerRepository implements PartnerRepository {
     ) {
       return null;
     }
-    return partner;
+    return maskPartnerBenefitsForAccess(partner, context);
   }
 
   async getPartnerByIdRaw(id: string): Promise<Partner | null> {

--- a/src/lib/repositories/partner-repository.ts
+++ b/src/lib/repositories/partner-repository.ts
@@ -1,7 +1,9 @@
 import type { Category, Partner } from "@/lib/types";
+import type { PartnerAudienceKey } from "@/lib/partner-audience";
 
 export type PartnerViewContext = {
   authenticated: boolean;
+  viewerAudience?: PartnerAudienceKey | null;
 };
 
 export interface PartnerRepository {

--- a/src/lib/repositories/supabase/partner-repository.supabase.ts
+++ b/src/lib/repositories/supabase/partner-repository.supabase.ts
@@ -13,6 +13,10 @@ import {
   canViewPartnerDetails,
   normalizePartnerVisibility,
 } from "@/lib/partner-visibility";
+import {
+  maskPartnerBenefitsForAccess,
+  normalizePartnerBenefitVisibility,
+} from "@/lib/partner-benefit-visibility";
 
 type PartnerRow = {
   id: string;
@@ -34,6 +38,7 @@ type PartnerRow = {
   images?: string[] | null;
   tags?: string[] | null;
   visibility?: string | null;
+  benefit_visibility?: string | null;
   categories?: { key?: string | null } | Array<{ key?: string | null }> | null;
 };
 
@@ -53,7 +58,7 @@ type PublicCacheVersionRow = {
 };
 
 const PARTNER_SELECT_COLUMNS =
-  "id,name,category_id,created_at,updated_at,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,categories(key)";
+  "id,name,category_id,created_at,updated_at,location,campus_slugs,thumbnail,map_url,reservation_link,inquiry_link,period_start,period_end,conditions,benefits,applies_to,images,tags,visibility,benefit_visibility,categories(key)";
 
 function normalizeDate(value: string | null | undefined) {
   return value ?? "미정";
@@ -181,6 +186,7 @@ function toVisiblePartner(row: PartnerRow, categoryKey: string): Partner {
     name: row.name,
     category: categoryKey,
     visibility: normalizePartnerVisibility(row.visibility),
+    benefitVisibility: normalizePartnerBenefitVisibility(row.benefit_visibility),
     createdAt: row.created_at,
     location: row.location,
     campusSlugs: normalizeCampusSlugs(row.campus_slugs ?? []),
@@ -206,6 +212,7 @@ function toLockedPartner(row: PartnerRow, categoryKey: string): Partner {
     name: "",
     category: categoryKey,
     visibility: normalizePartnerVisibility(row.visibility),
+    benefitVisibility: normalizePartnerBenefitVisibility(row.benefit_visibility),
     createdAt: row.created_at,
     location: "",
     campusSlugs: normalizeCampusSlugs(row.campus_slugs ?? []),
@@ -229,7 +236,7 @@ function mapPartnerForList(
   const categoryKey = extractCategoryKey(row.categories) ?? "health";
   const visibility = normalizePartnerVisibility(row.visibility);
   if (canViewPartnerDetails(visibility, context.authenticated)) {
-    return toVisiblePartner(row, categoryKey);
+    return maskPartnerBenefitsForAccess(toVisiblePartner(row, categoryKey), context);
   }
   return toLockedPartner(row, categoryKey);
 }
@@ -290,7 +297,7 @@ export class SupabasePartnerRepository implements PartnerRepository {
       return null;
     }
 
-    return toVisiblePartner(row, categoryKey);
+    return maskPartnerBenefitsForAccess(toVisiblePartner(row, categoryKey), context);
   }
 
   async getPartnerByIdRaw(id: string): Promise<Partner | null> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ import type {
   PartnerAudienceKey,
 } from "@/lib/partner-audience";
 import type { CampusSlug } from "@/lib/campuses";
+import type { PartnerBenefitVisibility } from "@/lib/partner-benefit-visibility";
 
 export type CategoryKey = string;
 export type PartnerVisibility = "public" | "confidential" | "private";
@@ -19,6 +20,7 @@ export type Partner = {
   name: string;
   category: CategoryKey;
   visibility: PartnerVisibility;
+  benefitVisibility?: PartnerBenefitVisibility;
   createdAt: string;
   location: string;
   campusSlugs?: CampusSlug[];

--- a/supabase/migrations/20260506203013_partner_benefit_visibility.sql
+++ b/supabase/migrations/20260506203013_partner_benefit_visibility.sql
@@ -1,0 +1,26 @@
+-- Add explicit benefit-level visibility separate from partner page visibility.
+-- Rollback, if needed:
+--   alter table public.partners drop constraint if exists partners_benefit_visibility_check;
+--   alter table public.partners drop column if exists benefit_visibility;
+
+alter table public.partners
+  add column if not exists benefit_visibility text not null default 'public';
+
+update public.partners
+set benefit_visibility = case lower(trim(coalesce(benefit_visibility, 'public')))
+  when 'eligible_only' then 'eligible_only'
+  else 'public'
+end;
+
+alter table public.partners
+  alter column benefit_visibility set default 'public';
+
+alter table public.partners
+  alter column benefit_visibility set not null;
+
+alter table public.partners
+  drop constraint if exists partners_benefit_visibility_check;
+
+alter table public.partners
+  add constraint partners_benefit_visibility_check
+  check (benefit_visibility in ('public', 'eligible_only'));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -45,6 +45,7 @@ create table if not exists partners (
   category_id uuid not null references categories(id) on delete cascade,
   name text not null,
   visibility text not null default 'public',
+  benefit_visibility text not null default 'public',
   location text not null,
   campus_slugs text[] not null default '{}',
   map_url text,
@@ -92,6 +93,7 @@ as $$
 $$;
 
 alter table partners add column if not exists visibility text not null default 'public';
+alter table partners add column if not exists benefit_visibility text not null default 'public';
 alter table partners add column if not exists campus_slugs text[] not null default '{}';
 update partners
 set visibility = case lower(trim(coalesce(visibility, 'public')))
@@ -105,6 +107,16 @@ alter table partners alter column visibility set not null;
 alter table partners drop constraint if exists partners_visibility_check;
 alter table partners add constraint partners_visibility_check
   check (visibility in ('public', 'confidential', 'private'));
+update partners
+set benefit_visibility = case lower(trim(coalesce(benefit_visibility, 'public')))
+  when 'eligible_only' then 'eligible_only'
+  else 'public'
+end;
+alter table partners alter column benefit_visibility set default 'public';
+alter table partners alter column benefit_visibility set not null;
+alter table partners drop constraint if exists partners_benefit_visibility_check;
+alter table partners add constraint partners_benefit_visibility_check
+  check (benefit_visibility in ('public', 'eligible_only'));
 update partners
 set campus_slugs = public.infer_partner_campus_slugs(location)
 where cardinality(campus_slugs) = 0;

--- a/tests/partner-benefit-visibility.test.mts
+++ b/tests/partner-benefit-visibility.test.mts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type BenefitVisibilityModule =
+  typeof import("../src/lib/partner-benefit-visibility.ts");
+type PartnerAudienceModule = typeof import("../src/lib/partner-audience.ts");
+type MockPartnerRepositoryModule =
+  typeof import("../src/lib/repositories/mock/partner-repository.mock.ts");
+
+const benefitVisibilityPromise = import(
+  new URL("../src/lib/partner-benefit-visibility.ts", import.meta.url).href,
+) as Promise<BenefitVisibilityModule>;
+const partnerAudiencePromise = import(
+  new URL("../src/lib/partner-audience.ts", import.meta.url).href,
+) as Promise<PartnerAudienceModule>;
+const mockPartnerRepositoryPromise = import(
+  new URL("../src/lib/repositories/mock/partner-repository.mock.ts", import.meta.url).href,
+) as Promise<MockPartnerRepositoryModule>;
+
+test("benefit visibility masks eligible-only benefits for logged out users", async () => {
+  const {
+    BENEFIT_LOGIN_REQUIRED_MESSAGE,
+    maskPartnerBenefitsForAccess,
+  } = await benefitVisibilityPromise;
+
+  const partner = {
+    id: "partner-1",
+    name: "테스트 제휴",
+    category: "health",
+    visibility: "public" as const,
+    benefitVisibility: "eligible_only" as const,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    location: "서울",
+    reservationLink: "https://reserve.example.com",
+    period: { start: "2026-05-01", end: "2026-12-31" },
+    conditions: ["SSAFY 인증 화면 제시"],
+    benefits: ["10% 할인"],
+    appliesTo: ["student" as const],
+  };
+
+  const masked = maskPartnerBenefitsForAccess(partner, {
+    authenticated: false,
+  });
+
+  assert.equal(masked.reservationLink, undefined);
+  assert.deepEqual(masked.benefits, [BENEFIT_LOGIN_REQUIRED_MESSAGE]);
+  assert.deepEqual(masked.conditions, [BENEFIT_LOGIN_REQUIRED_MESSAGE]);
+});
+
+test("benefit visibility masks eligible-only benefits for non-eligible users", async () => {
+  const {
+    BENEFIT_ELIGIBLE_ONLY_MESSAGE,
+    maskPartnerBenefitsForAccess,
+  } = await benefitVisibilityPromise;
+
+  const partner = {
+    id: "partner-1",
+    name: "테스트 제휴",
+    category: "health",
+    visibility: "public" as const,
+    benefitVisibility: "eligible_only" as const,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    location: "서울",
+    reservationLink: "https://reserve.example.com",
+    period: { start: "2026-05-01", end: "2026-12-31" },
+    conditions: ["SSAFY 인증 화면 제시"],
+    benefits: ["10% 할인"],
+    appliesTo: ["student" as const],
+  };
+
+  const masked = maskPartnerBenefitsForAccess(partner, {
+    authenticated: true,
+    viewerAudience: "graduate",
+  });
+
+  assert.equal(masked.reservationLink, undefined);
+  assert.deepEqual(masked.benefits, [BENEFIT_ELIGIBLE_ONLY_MESSAGE]);
+  assert.deepEqual(masked.conditions, [BENEFIT_ELIGIBLE_ONLY_MESSAGE]);
+});
+
+test("benefit visibility preserves eligible-only benefits for eligible users", async () => {
+  const { maskPartnerBenefitsForAccess } = await benefitVisibilityPromise;
+
+  const partner = {
+    id: "partner-1",
+    name: "테스트 제휴",
+    category: "health",
+    visibility: "public" as const,
+    benefitVisibility: "eligible_only" as const,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    location: "서울",
+    reservationLink: "https://reserve.example.com",
+    period: { start: "2026-05-01", end: "2026-12-31" },
+    conditions: ["SSAFY 인증 화면 제시"],
+    benefits: ["10% 할인"],
+    appliesTo: ["student" as const],
+  };
+
+  const visible = maskPartnerBenefitsForAccess(partner, {
+    authenticated: true,
+    viewerAudience: "student",
+  });
+
+  assert.equal(visible.reservationLink, "https://reserve.example.com");
+  assert.deepEqual(visible.benefits, ["10% 할인"]);
+  assert.deepEqual(visible.conditions, ["SSAFY 인증 화면 제시"]);
+});
+
+test("member year maps to partner audience for benefit eligibility", async () => {
+  const { resolvePartnerAudienceFromMemberYear } = await partnerAudiencePromise;
+
+  assert.equal(resolvePartnerAudienceFromMemberYear(0), "staff");
+  assert.equal(resolvePartnerAudienceFromMemberYear(15), "student");
+  assert.equal(resolvePartnerAudienceFromMemberYear(13), "graduate");
+  assert.equal(resolvePartnerAudienceFromMemberYear(null), null);
+});
+
+test("mock partner repository applies benefit masking at list boundary", async () => {
+  const {
+    BENEFIT_LOGIN_REQUIRED_MESSAGE,
+    BENEFIT_ELIGIBLE_ONLY_MESSAGE,
+  } = await benefitVisibilityPromise;
+  const { MockPartnerRepository } = await mockPartnerRepositoryPromise;
+  const repository = new MockPartnerRepository();
+
+  const loggedOutPartners = await repository.getPartners({ authenticated: false });
+  const loggedOutHealth = loggedOutPartners.find((partner) => partner.id === "health-001");
+  assert.deepEqual(loggedOutHealth?.benefits, [BENEFIT_LOGIN_REQUIRED_MESSAGE]);
+
+  const graduatePartners = await repository.getPartners({
+    authenticated: true,
+    viewerAudience: "graduate",
+  });
+  const graduateHealth = graduatePartners.find((partner) => partner.id === "health-001");
+  assert.deepEqual(graduateHealth?.benefits, [BENEFIT_ELIGIBLE_ONLY_MESSAGE]);
+
+  const studentPartners = await repository.getPartners({
+    authenticated: true,
+    viewerAudience: "student",
+  });
+  const studentHealth = studentPartners.find((partner) => partner.id === "health-001");
+  assert.equal(studentHealth?.reservationLink, "https://booking.naver.com/");
+});


### PR DESCRIPTION
## Summary
- 브랜드 카드/상세 공개 여부와 별도로 혜택성 정보 공개 범위를 분리합니다.
- `partners.benefit_visibility`를 추가하고 기본값은 기존 동작 보존을 위해 `public`으로 둡니다.
- `eligible_only` 브랜드는 로그인/대상자 상태에 따라 혜택, 조건, 혜택 이용 링크를 마스킹합니다.

## Related Issue
Refs #15

## Branch Flow
- base: `dev`
- head: `feat/benefit-visibility-scope`
- Issue의 PR 3 범위입니다.

## Changes
- `partners.benefit_visibility` migration과 schema snapshot을 추가했습니다.
- `Partner` 타입, Supabase/mock repository 매핑, public list/detail 조회 masking helper를 추가했습니다.
- 비로그인 사용자는 `로그인 후 조회 가능합니다.`, 로그인했지만 대상자가 아닌 사용자는 `혜택 대상자만 조회 가능합니다.` 문구를 보도록 처리했습니다.
- 관리자 브랜드 생성/수정 폼에 혜택 공개 범위 선택을 추가했습니다.
- 혜택 공개 범위 단위 테스트를 추가했습니다.

## Test Plan
- [x] `node --import ./tests/alias-register.mjs --test tests/partner-benefit-visibility.test.mts`
- [x] `npx eslint <changed files>`
- [x] `npm run build`
- [x] `npm run release` 내부 Storybook build/test-storybook 통과

## Checklist
- [x] PR 대상 브랜치가 `dev`입니다.
- [x] PR 본문에 `Refs #15`를 사용했습니다.
- [x] DB migration 변경을 포함했습니다.
- [x] diff와 focused verification을 확인했습니다.