### PR TITLE
feat: signup-reward 이벤트 현황 완성

### DIFF
--- a/src/app/(site)/events/[slug]/page.tsx
+++ b/src/app/(site)/events/[slug]/page.tsx
@@ -145,6 +145,7 @@ export default async function EventPage({
           <EventLanding
             campaign={campaign}
             summary={summary}
+            showHeroImage={campaign.slug !== "signup-reward"}
           />
           {registration?.source !== "database" || !registration.isActive ? (
             <Card tone="muted" padding="md" className="mt-5">

--- a/src/app/admin/(protected)/event/[slug]/page.tsx
+++ b/src/app/admin/(protected)/event/[slug]/page.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/app/admin/(protected)/_actions/promotion-actions";
 import { getEventPageDefinition } from "@/lib/event-pages";
 import { PROMOTION_AUDIENCE_OPTIONS } from "@/lib/promotions/catalog";
+import {
+  getEventRewardAdminOverview,
+  type EventRewardAdminMemberRow,
+  type EventRewardAdminOverview,
+} from "@/lib/promotions/event-rewards";
 import { listManagedEventCampaigns, type ManagedEventCampaign } from "@/lib/promotions/events";
 
 export const dynamic = "force-dynamic";
@@ -79,6 +84,146 @@ function getEventState(campaign: ManagedEventCampaign | null) {
   };
 }
 
+function rewardConditionLabel(
+  row: EventRewardAdminMemberRow,
+  key: "signup" | "mm" | "push" | "marketing" | "review",
+) {
+  const condition = row.conditions.find((item) => item.key === key);
+  if (key === "review") {
+    return `${condition?.currentCount ?? 0}개`;
+  }
+  return condition?.status === "received" ? "완료" : "-";
+}
+
+function RewardStatusPill({
+  value,
+  muted = false,
+}: {
+  value: string;
+  muted?: boolean;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
+        value === "완료" && !muted
+          ? "border-primary/20 bg-primary-soft text-primary"
+          : "border-border/70 bg-surface-inset text-muted-foreground"
+      }`}
+    >
+      {value}
+    </span>
+  );
+}
+
+function SignupRewardOverviewSection({
+  overview,
+}: {
+  overview: EventRewardAdminOverview;
+}) {
+  const conditionStats = [
+    { label: "회원가입", value: `${overview.conditionCounts.signup ?? 0}명` },
+    { label: "MM 알림", value: `${overview.conditionCounts.mm ?? 0}명` },
+    { label: "푸시", value: `${overview.conditionCounts.push ?? 0}명` },
+    { label: "마케팅", value: `${overview.conditionCounts.marketing ?? 0}명` },
+  ];
+
+  return (
+    <section className="grid gap-5" aria-label="추첨권 현황">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="ui-kicker">Rewards</p>
+          <h3 className="mt-2 text-xl font-semibold text-foreground">
+            추첨권 현황
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            이벤트 종료 전 가입자는 회원가입 추첨권 1장을 완료 처리합니다.
+          </p>
+        </div>
+        <Button href="/admin/event/signup-reward/rewards/export" variant="secondary">
+          CSV 내보내기
+        </Button>
+      </div>
+
+      <StatsRow
+        items={[
+          { label: "대상 회원", value: `${overview.memberCount.toLocaleString()}명`, hint: "전체 회원" },
+          { label: "총 추첨권", value: `${overview.totalTickets.toLocaleString()}장`, hint: "현재 조건 기준" },
+          { label: "리뷰 인정", value: `${overview.reviewCount.toLocaleString()}개`, hint: "이벤트 기간 visible 리뷰" },
+          { label: "가입 완료", value: `${(overview.conditionCounts.signup ?? 0).toLocaleString()}명`, hint: "종료 전 가입자" },
+        ]}
+        minItemWidth="13rem"
+      />
+
+      <Card tone="muted" className="grid gap-3">
+        <div className="flex flex-wrap gap-2">
+          {conditionStats.map((item) => (
+            <span
+              key={item.label}
+              className="rounded-full border border-border/70 bg-surface px-2.5 py-1 text-xs font-semibold text-muted-foreground"
+            >
+              {item.label} · {item.value}
+            </span>
+          ))}
+        </div>
+      </Card>
+
+      <Card tone="elevated" padding="none" className="overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-[960px] w-full text-left text-sm">
+            <thead className="border-b border-border bg-surface-inset text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">회원</th>
+                <th className="px-4 py-3">기수/캠퍼스</th>
+                <th className="px-4 py-3 text-right">총 추첨권</th>
+                <th className="px-4 py-3">signup</th>
+                <th className="px-4 py-3">mm</th>
+                <th className="px-4 py-3">push</th>
+                <th className="px-4 py-3">marketing</th>
+                <th className="px-4 py-3">review</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/70">
+              {overview.members.map((member) => (
+                <tr key={member.id} className="align-middle">
+                  <td className="px-4 py-3">
+                    <p className="font-semibold text-foreground">
+                      {member.displayName || member.mmUsername}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {member.mmUsername}
+                    </p>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {member.year}기 · {member.campus || "-"}
+                  </td>
+                  <td className="px-4 py-3 text-right text-base font-semibold text-foreground">
+                    {member.totalTickets.toLocaleString()}장
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "signup")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "mm")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "push")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "marketing")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "review")} muted />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </section>
+  );
+}
+
 export default async function AdminEventDetailPage({
   params,
   searchParams,
@@ -95,9 +240,12 @@ export default async function AdminEventDetailPage({
 
   const campaigns = await listManagedEventCampaigns({ includeInactive: true });
   const registration = campaigns.find((campaign) => campaign.slug === slug) ?? null;
+  const campaign = registration ?? definition;
   const isRegistered = registration?.source === "database" && Boolean(registration.id);
   const state = getEventState(registration);
   const message = statusMessage(paramsData.status);
+  const rewardOverview =
+    slug === "signup-reward" ? await getEventRewardAdminOverview(campaign) : null;
   const targetLabel =
     registration?.targetAudiences?.map(
       (audience) => PROMOTION_AUDIENCE_OPTIONS.find((option) => option.key === audience)?.label ?? audience,
@@ -230,6 +378,10 @@ export default async function AdminEventDetailPage({
             </ul>
           </Card>
         </div>
+
+        {rewardOverview ? (
+          <SignupRewardOverviewSection overview={rewardOverview} />
+        ) : null}
       </div>
     </AdminShell>
   );

--- a/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
+++ b/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { getEventPageDefinition } from "@/lib/event-pages";
+import {
+  createEventRewardCsv,
+  getEventRewardAdminOverview,
+} from "@/lib/promotions/event-rewards";
+import { getManagedEventCampaign } from "@/lib/promotions/events";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  await requireAdmin();
+
+  const definition = getEventPageDefinition("signup-reward");
+  if (!definition) {
+    return NextResponse.json({ message: "이벤트 정의를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const campaign = (await getManagedEventCampaign("signup-reward")) ?? definition;
+  const overview = await getEventRewardAdminOverview(campaign);
+  const csv = createEventRewardCsv(overview);
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="signup-reward-rewards.csv"',
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/components/events/EventLanding.tsx
+++ b/src/components/events/EventLanding.tsx
@@ -24,16 +24,18 @@ const conditionIcons: Record<EventConditionKey, typeof UserPlusIcon> = {
 export default function EventLanding({
   campaign,
   summary,
+  showHeroImage = true,
 }: {
   campaign: EventCampaign;
   summary: EventRewardSummary;
+  showHeroImage?: boolean;
 }) {
   const summaryMap = new Map(summary.conditions.map((condition) => [condition.key, condition]));
 
   return (
     <div className="space-y-5">
       <Card tone="hero" padding="none" className="overflow-hidden">
-        <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_24rem]">
+        <div className={showHeroImage ? "grid gap-0 lg:grid-cols-[minmax(0,1fr)_24rem]" : "grid gap-0"}>
           <div className="p-6 sm:p-8 lg:p-10">
             <p className="text-sm font-semibold uppercase tracking-[0.22em] opacity-80">
               Event
@@ -46,16 +48,18 @@ export default function EventLanding({
             </p>
             <p className="mt-4 text-sm font-semibold opacity-90">{campaign.periodLabel}</p>
           </div>
-          <div className="relative min-h-48 border-t border-white/10 bg-black/15 lg:border-l lg:border-t-0">
-            <Image
-              src={campaign.heroImageSrc}
-              alt={campaign.heroImageAlt}
-              fill
-              priority
-              sizes="(min-width: 1024px) 384px, calc(100vw - 32px)"
-              className="object-cover"
-            />
-          </div>
+          {showHeroImage ? (
+            <div className="relative min-h-48 border-t border-white/10 bg-black/15 lg:border-l lg:border-t-0">
+              <Image
+                src={campaign.heroImageSrc}
+                alt={campaign.heroImageAlt}
+                fill
+                priority
+                sizes="(min-width: 1024px) 384px, calc(100vw - 32px)"
+                className="object-cover"
+              />
+            </div>
+          ) : null}
         </div>
       </Card>
 

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -1,5 +1,8 @@
 import { getMemberNotificationPreferences } from "@/lib/notification-preferences";
 import { fetchMemberVisibleReviewCountInRange } from "@/lib/partner-counts";
+import { collectPagedRows } from "@/lib/log-insights/paging";
+import { getPolicyDocumentByKind } from "@/lib/policy-documents";
+import { getPushPreferencesOrDefault } from "@/lib/push";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import type { EventCampaign, EventConditionKey } from "@/lib/promotions/catalog";
 
@@ -28,16 +31,113 @@ type MemberRewardSnapshot = {
   reviewCount: number;
 };
 
-function isWithinCampaign(value: string | null, campaign: EventCampaign) {
+export type EventRewardAdminMemberInput = {
+  id: string;
+  displayName: string | null;
+  mmUsername: string;
+  year: number;
+  campus: string | null;
+  createdAt: string | null;
+  preferences: MemberRewardSnapshot["preferences"];
+  reviewCount: number;
+};
+
+export type EventRewardAdminMemberRow = EventRewardAdminMemberInput & {
+  totalTickets: number;
+  conditions: EventRewardConditionSummary[];
+};
+
+export type EventRewardAdminOverview = {
+  memberCount: number;
+  totalTickets: number;
+  reviewCount: number;
+  conditionCounts: Record<EventConditionKey, number>;
+  members: EventRewardAdminMemberRow[];
+};
+
+type MemberRow = {
+  id: string;
+  display_name: string | null;
+  mm_username: string | null;
+  year: number | null;
+  campus: string | null;
+  marketing_policy_version: number | null;
+  created_at: string | null;
+};
+
+type PreferenceRow = {
+  member_id: string | null;
+  enabled: boolean | null;
+  mm_enabled: boolean | null;
+};
+
+type ReviewRow = {
+  member_id: string | null;
+};
+
+function isJoinedByCampaignEnd(value: string | null, campaign: EventCampaign) {
   if (!value) {
     return false;
   }
   const time = new Date(value).getTime();
-  return (
-    Number.isFinite(time) &&
-    time >= new Date(campaign.startsAt).getTime() &&
-    time <= new Date(campaign.endsAt).getTime()
-  );
+  return Number.isFinite(time) && time <= new Date(campaign.endsAt).getTime();
+}
+
+export function calculateEventRewardConditions(
+  campaign: EventCampaign,
+  snapshot: MemberRewardSnapshot,
+): EventRewardConditionSummary[] {
+  return campaign.conditions.map<EventRewardConditionSummary>((condition) => {
+    if (condition.key === "signup") {
+      const received = isJoinedByCampaignEnd(snapshot.createdAt, campaign);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "mm") {
+      const received = Boolean(snapshot.preferences?.mmEnabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "push") {
+      const received = Boolean(snapshot.preferences?.enabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "marketing") {
+      const received = Boolean(snapshot.preferences?.marketingEnabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    const reviewCount = snapshot.reviewCount;
+    return {
+      key: condition.key,
+      status: reviewCount > 0 ? "received" : "missing",
+      earnedTickets: reviewCount * condition.tickets,
+      currentCount: reviewCount,
+    };
+  });
+}
+
+export function sumEventRewardTickets(
+  conditions: readonly EventRewardConditionSummary[],
+) {
+  return conditions.reduce((sum, condition) => sum + condition.earnedTickets, 0);
 }
 
 async function getMemberRewardSnapshot(
@@ -83,55 +183,206 @@ export async function getEventRewardSummary(params: {
 
   const snapshot = await getMemberRewardSnapshot(params.memberId, params.campaign);
 
-  const conditions = params.campaign.conditions.map<EventRewardConditionSummary>((condition) => {
-    if (condition.key === "signup") {
-      const received = isWithinCampaign(snapshot.createdAt, params.campaign);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+  const conditions = calculateEventRewardConditions(params.campaign, snapshot);
 
-    if (condition.key === "mm") {
-      const received = Boolean(snapshot.preferences?.mmEnabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+  return {
+    authenticated: true,
+    totalTickets: sumEventRewardTickets(conditions),
+    conditions,
+  };
+}
 
-    if (condition.key === "push") {
-      const received = Boolean(snapshot.preferences?.enabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+export function buildEventRewardAdminOverview(
+  campaign: EventCampaign,
+  members: readonly EventRewardAdminMemberInput[],
+): EventRewardAdminOverview {
+  const conditionCounts = Object.fromEntries(
+    campaign.conditions.map((condition) => [condition.key, 0]),
+  ) as Record<EventConditionKey, number>;
 
-    if (condition.key === "marketing") {
-      const received = Boolean(snapshot.preferences?.marketingEnabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
+  const rows = members.map<EventRewardAdminMemberRow>((member) => {
+    const conditions = calculateEventRewardConditions(campaign, {
+      createdAt: member.createdAt,
+      preferences: member.preferences,
+      reviewCount: member.reviewCount,
+    });
+    for (const condition of conditions) {
+      if (condition.status === "received") {
+        conditionCounts[condition.key] = (conditionCounts[condition.key] ?? 0) + 1;
+      }
     }
-
-    const reviewCount = snapshot.reviewCount;
     return {
-      key: condition.key,
-      status: reviewCount > 0 ? "received" : "missing",
-      earnedTickets: reviewCount * condition.tickets,
-      currentCount: reviewCount,
+      ...member,
+      totalTickets: sumEventRewardTickets(conditions),
+      conditions,
     };
   });
 
   return {
-    authenticated: true,
-    totalTickets: conditions.reduce((sum, condition) => sum + condition.earnedTickets, 0),
-    conditions,
+    memberCount: rows.length,
+    totalTickets: rows.reduce((sum, row) => sum + row.totalTickets, 0),
+    reviewCount: rows.reduce((sum, row) => sum + row.reviewCount, 0),
+    conditionCounts,
+    members: rows.sort((a, b) => {
+      if (b.totalTickets !== a.totalTickets) {
+        return b.totalTickets - a.totalTickets;
+      }
+      return (a.displayName ?? a.mmUsername).localeCompare(
+        b.displayName ?? b.mmUsername,
+        "ko",
+      );
+    }),
   };
+}
+
+function csvCell(value: string | number | null | undefined) {
+  const text = String(value ?? "");
+  return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function conditionStatusLabel(
+  row: EventRewardAdminMemberRow,
+  key: EventConditionKey,
+) {
+  const condition = row.conditions.find((item) => item.key === key);
+  if (key === "review") {
+    return String(condition?.currentCount ?? 0);
+  }
+  return condition?.status === "received" ? "완료" : "미완료";
+}
+
+export function createEventRewardCsv(overview: EventRewardAdminOverview) {
+  const headers = [
+    "이름",
+    "MM ID",
+    "기수",
+    "캠퍼스",
+    "총 추첨권",
+    "signup",
+    "mm",
+    "push",
+    "marketing",
+    "review",
+  ];
+  const rows = overview.members.map((member) => [
+    member.displayName ?? "",
+    member.mmUsername,
+    member.year,
+    member.campus ?? "",
+    member.totalTickets,
+    conditionStatusLabel(member, "signup"),
+    conditionStatusLabel(member, "mm"),
+    conditionStatusLabel(member, "push"),
+    conditionStatusLabel(member, "marketing"),
+    conditionStatusLabel(member, "review"),
+  ]);
+
+  return `\uFEFF${[headers, ...rows]
+    .map((row) => row.map((value) => csvCell(value)).join(","))
+    .join("\n")}`;
+}
+
+function normalizePreferences(params: {
+  row?: PreferenceRow | null;
+  marketingEnabled: boolean;
+}): MemberRewardSnapshot["preferences"] {
+  const preferences = getPushPreferencesOrDefault(
+    params.row
+      ? {
+          enabled: params.row.enabled ?? undefined,
+          mmEnabled: params.row.mm_enabled ?? undefined,
+        }
+      : null,
+  );
+  return {
+    enabled: preferences.enabled,
+    mmEnabled: preferences.mmEnabled,
+    marketingEnabled: params.marketingEnabled,
+  };
+}
+
+async function fetchAllEventMembers(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+) {
+  const result = await collectPagedRows<MemberRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("members")
+      .select("id,display_name,mm_username,year,campus,marketing_policy_version,created_at")
+      .order("year", { ascending: false })
+      .order("display_name", { ascending: true })
+      .range(from, to);
+    return { rows: (data ?? []) as MemberRow[], error: Boolean(error) };
+  });
+  return result.rows;
+}
+
+async function fetchAllEventPreferences(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+) {
+  const result = await collectPagedRows<PreferenceRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("push_preferences")
+      .select("member_id,enabled,mm_enabled")
+      .range(from, to);
+    return { rows: (data ?? []) as PreferenceRow[], error: Boolean(error) };
+  });
+  return result.rows;
+}
+
+async function fetchAllEventReviewCounts(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+  campaign: EventCampaign,
+) {
+  const result = await collectPagedRows<ReviewRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("partner_reviews")
+      .select("member_id")
+      .gte("created_at", campaign.startsAt)
+      .lte("created_at", campaign.endsAt)
+      .is("deleted_at", null)
+      .is("hidden_at", null)
+      .range(from, to);
+    return { rows: (data ?? []) as ReviewRow[], error: Boolean(error) };
+  });
+  const counts = new Map<string, number>();
+  for (const row of result.rows) {
+    if (!row.member_id) {
+      continue;
+    }
+    counts.set(row.member_id, (counts.get(row.member_id) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export async function getEventRewardAdminOverview(campaign: EventCampaign) {
+  const supabase = getSupabaseAdminClient();
+  const [members, preferences, reviewCounts] = await Promise.all([
+    fetchAllEventMembers(supabase),
+    fetchAllEventPreferences(supabase),
+    fetchAllEventReviewCounts(supabase, campaign),
+  ]);
+  const activeMarketingPolicy = await getPolicyDocumentByKind("marketing").catch(
+    () => null,
+  );
+  const preferenceMap = new Map(preferences.map((row) => [row.member_id ?? "", row]));
+
+  return buildEventRewardAdminOverview(
+    campaign,
+    members.map((member) => ({
+      id: member.id,
+      displayName: member.display_name,
+      mmUsername: member.mm_username ?? "",
+      year: member.year ?? 0,
+      campus: member.campus,
+      createdAt: member.created_at,
+      preferences: normalizePreferences({
+        row: preferenceMap.get(member.id),
+        marketingEnabled: Boolean(
+          activeMarketingPolicy &&
+            member.marketing_policy_version === activeMarketingPolicy.version,
+        ),
+      }),
+      reviewCount: reviewCounts.get(member.id) ?? 0,
+    })),
+  );
 }

--- a/tests/event-reward-admin.test.mts
+++ b/tests/event-reward-admin.test.mts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type EventRewardsModule = typeof import("../src/lib/promotions/event-rewards.ts");
+
+const eventRewardsModulePromise = import(
+  new URL("../src/lib/promotions/event-rewards.ts", import.meta.url).href
+) as Promise<EventRewardsModule>;
+
+const campaign = {
+  slug: "signup-reward",
+  title: "싸트너십 추첨권 이벤트",
+  shortTitle: "추첨권 이벤트",
+  description: "테스트 이벤트",
+  periodLabel: "테스트 기간",
+  startsAt: "2026-04-20T00:00:00+09:00",
+  endsAt: "2026-05-12T23:59:59+09:00",
+  heroImageSrc: "/ads/reward-event.svg",
+  heroImageAlt: "이벤트",
+  conditions: [
+    {
+      key: "signup" as const,
+      title: "회원가입",
+      description: "가입",
+      tickets: 1,
+      ctaHref: "/auth/signup",
+      ctaLabel: "회원가입",
+    },
+    {
+      key: "mm" as const,
+      title: "MM",
+      description: "MM",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "알림",
+    },
+    {
+      key: "push" as const,
+      title: "Push",
+      description: "Push",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "푸시",
+    },
+    {
+      key: "marketing" as const,
+      title: "Marketing",
+      description: "Marketing",
+      tickets: 2,
+      ctaHref: "/notifications",
+      ctaLabel: "동의",
+    },
+    {
+      key: "review" as const,
+      title: "Review",
+      description: "Review",
+      tickets: 1,
+      ctaHref: "/",
+      ctaLabel: "리뷰",
+      repeatable: true,
+    },
+  ],
+  rules: [],
+};
+
+test("event reward admin overview aggregates member rows and condition counts", async () => {
+  const { buildEventRewardAdminOverview } = await eventRewardsModulePromise;
+
+  const overview = buildEventRewardAdminOverview(campaign, [
+    {
+      id: "member-1",
+      displayName: "김싸피",
+      mmUsername: "kim",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: true,
+        marketingEnabled: false,
+      },
+      reviewCount: 2,
+    },
+    {
+      id: "member-2",
+      displayName: "이싸피",
+      mmUsername: "lee",
+      year: 14,
+      campus: "구미",
+      createdAt: "2026-05-13T00:00:00+09:00",
+      preferences: {
+        enabled: false,
+        mmEnabled: false,
+        marketingEnabled: true,
+      },
+      reviewCount: 0,
+    },
+  ]);
+
+  assert.equal(overview.memberCount, 2);
+  assert.equal(overview.totalTickets, 7);
+  assert.equal(overview.conditionCounts.signup, 1);
+  assert.equal(overview.conditionCounts.mm, 1);
+  assert.equal(overview.conditionCounts.push, 1);
+  assert.equal(overview.conditionCounts.marketing, 1);
+  assert.equal(overview.reviewCount, 2);
+  assert.equal(overview.members[0]?.totalTickets, 5);
+  assert.equal(overview.members[1]?.totalTickets, 2);
+});
+
+test("event reward csv export uses the same row values as admin overview", async () => {
+  const { buildEventRewardAdminOverview, createEventRewardCsv } =
+    await eventRewardsModulePromise;
+
+  const overview = buildEventRewardAdminOverview(campaign, [
+    {
+      id: "member-1",
+      displayName: "김,싸피",
+      mmUsername: "kim",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: false,
+        marketingEnabled: true,
+      },
+      reviewCount: 1,
+    },
+  ]);
+  const csv = createEventRewardCsv(overview);
+
+  assert.ok(csv.startsWith("\uFEFF"));
+  assert.match(csv, /이름,MM ID,기수,캠퍼스,총 추첨권/);
+  assert.match(csv, /"김,싸피",kim,15,서울,5,완료,미완료,완료,완료,1/);
+});

--- a/tests/event-rewards.test.mts
+++ b/tests/event-rewards.test.mts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type EventRewardsModule = typeof import("../src/lib/promotions/event-rewards.ts");
+
+const eventRewardsModulePromise = import(
+  new URL("../src/lib/promotions/event-rewards.ts", import.meta.url).href
+) as Promise<EventRewardsModule>;
+
+const campaign = {
+  slug: "signup-reward",
+  title: "싸트너십 추첨권 이벤트",
+  shortTitle: "추첨권 이벤트",
+  description: "테스트 이벤트",
+  periodLabel: "테스트 기간",
+  startsAt: "2026-04-20T00:00:00+09:00",
+  endsAt: "2026-05-12T23:59:59+09:00",
+  heroImageSrc: "/ads/reward-event.svg",
+  heroImageAlt: "이벤트",
+  conditions: [
+    {
+      key: "signup" as const,
+      title: "회원가입",
+      description: "가입",
+      tickets: 1,
+      ctaHref: "/auth/signup",
+      ctaLabel: "회원가입",
+    },
+    {
+      key: "mm" as const,
+      title: "MM",
+      description: "MM",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "알림",
+    },
+    {
+      key: "push" as const,
+      title: "Push",
+      description: "Push",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "푸시",
+    },
+    {
+      key: "marketing" as const,
+      title: "Marketing",
+      description: "Marketing",
+      tickets: 2,
+      ctaHref: "/notifications",
+      ctaLabel: "동의",
+    },
+    {
+      key: "review" as const,
+      title: "Review",
+      description: "Review",
+      tickets: 1,
+      ctaHref: "/",
+      ctaLabel: "리뷰",
+      repeatable: true,
+    },
+  ],
+  rules: [],
+};
+
+test("event reward signup condition includes members created before the campaign", async () => {
+  const { calculateEventRewardConditions } = await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-04-01T12:00:00+09:00",
+    preferences: null,
+    reviewCount: 0,
+  });
+
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.status, "received");
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.earnedTickets, 1);
+});
+
+test("event reward signup condition excludes members created after the campaign", async () => {
+  const { calculateEventRewardConditions } = await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-05-13T00:00:00+09:00",
+    preferences: {
+      enabled: true,
+      mmEnabled: true,
+      marketingEnabled: true,
+    },
+    reviewCount: 3,
+  });
+
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.status, "missing");
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.earnedTickets, 0);
+});
+
+test("event reward conditions sum signup, notification, marketing, and review tickets", async () => {
+  const { calculateEventRewardConditions, sumEventRewardTickets } =
+    await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-05-01T12:00:00+09:00",
+    preferences: {
+      enabled: true,
+      mmEnabled: false,
+      marketingEnabled: true,
+    },
+    reviewCount: 2,
+  });
+
+  assert.equal(sumEventRewardTickets(conditions), 6);
+  assert.deepEqual(
+    conditions.map((condition) => [condition.key, condition.earnedTickets]),
+    [
+      ["signup", 1],
+      ["mm", 0],
+      ["push", 1],
+      ["marketing", 2],
+      ["review", 2],
+    ],
+  );
+});


### PR DESCRIPTION
## Summary
- signup-reward 회원가입 추첨권을 이벤트 종료 전 가입자 전체 기준으로 계산합니다.
- /events/signup-reward 본문 히어로 이미지를 숨기고 배너/OG 이미지는 유지합니다.
- /admin/event/signup-reward에 추첨권 현황과 CSV 내보내기를 추가합니다.

## Related Issue
Refs #24

## Branch Flow
- base: dev
- branch: feat/signup-reward-status
- target: dev

## Changes
- 이벤트 보상 계산 helper를 사용자 요약, 어드민 현황, CSV export가 공유하도록 정리
- signup 조건을 campaign.endsAt 이전 가입 기준으로 변경
- signup-reward 전용 admin 현황 표와 CSV export route 추가

## Test Plan
- [x] node --import ./tests/alias-register.mjs --test tests/event-reward-admin.test.mts tests/event-rewards.test.mts
- [x] npx eslint src/lib/promotions/event-rewards.ts src/components/events/EventLanding.tsx src/app/(site)/events/[slug]/page.tsx src/app/admin/(protected)/event/[slug]/page.tsx src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts tests/event-reward-admin.test.mts tests/event-rewards.test.mts
- [x] npm run build

## Checklist
- [x] Issue 생성 및 연결
- [x] dev 대상 typed branch에서 작업
- [x] admin export route에 requireAdmin 적용
