### PR TITLE
release: dev 변경사항 프로덕션 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.21",
+  "version": "1.9.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.21",
+      "version": "1.9.22",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.19",
+  "version": "1.9.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.19",
+      "version": "1.9.20",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.20",
+  "version": "1.9.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.20",
+      "version": "1.9.21",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.19",
+  "version": "1.9.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.21",
+  "version": "1.9.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.20",
+  "version": "1.9.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/(site)/events/[slug]/page.tsx
+++ b/src/app/(site)/events/[slug]/page.tsx
@@ -145,6 +145,7 @@ export default async function EventPage({
           <EventLanding
             campaign={campaign}
             summary={summary}
+            showHeroImage={campaign.slug !== "signup-reward"}
           />
           {registration?.source !== "database" || !registration.isActive ? (
             <Card tone="muted" padding="md" className="mt-5">

--- a/src/app/admin/(protected)/_actions/promotion-actions.ts
+++ b/src/app/admin/(protected)/_actions/promotion-actions.ts
@@ -222,30 +222,44 @@ export async function createPromotionEventAction(formData: FormData) {
 export async function updatePromotionEventAction(formData: FormData) {
   await requireAdmin();
   const id = getRequiredString(formData, "id");
+  const slug = normalizeSlug(getRequiredString(formData, "slug"));
   const supabase = getSupabaseAdminClient();
   const { data: existing, error: existingError } = await supabase
     .from("promotion_events")
-    .select("slug")
+    .select("id,slug")
     .eq("id", id)
     .maybeSingle();
   if (existingError) {
     throw new Error(existingError.message);
   }
-  if (!existing?.slug) {
-    throw new Error("이벤트를 찾지 못했습니다.");
+
+  const { data: existingBySlug, error: existingBySlugError } = existing?.slug
+    ? { data: null, error: null }
+    : await supabase
+        .from("promotion_events")
+        .select("id,slug")
+        .eq("slug", slug)
+        .maybeSingle();
+  if (existingBySlugError) {
+    throw new Error(existingBySlugError.message);
   }
-  const payload = parsePromotionEventRegistration(formData, existing.slug);
-  const { error } = await supabase.from("promotion_events").update(payload).eq("id", id);
+
+  const target = existing ?? existingBySlug;
+  const payload = parsePromotionEventRegistration(formData, target?.slug ?? slug);
+  const { error } = target?.id
+    ? await supabase.from("promotion_events").update(payload).eq("id", target.id)
+    : await supabase.from("promotion_events").insert(payload);
   if (error) {
     throw new Error(error.message);
   }
   await logAdminAction("promotion_event_update", {
     targetType: "promotion_event",
-    targetId: id,
+    targetId: target?.id ?? payload.slug,
     properties: {
       slug: payload.slug,
       pagePath: payload.page_path,
       targetAudiences: payload.target_audiences,
+      recoveredFromMissingId: !existing?.id,
     },
   });
   revalidatePromotionPaths(payload.slug);

--- a/src/app/admin/(protected)/advertisement/page.tsx
+++ b/src/app/admin/(protected)/advertisement/page.tsx
@@ -6,7 +6,10 @@ import SectionHeading from "@/components/ui/SectionHeading";
 import ShellHeader from "@/components/ui/ShellHeader";
 import StatsRow from "@/components/ui/StatsRow";
 import { savePromotionSlidesAction } from "@/app/admin/(protected)/_actions/promotion-actions";
-import { listManagedPromotionSlides } from "@/lib/promotions/events";
+import {
+  listManagedEventCampaigns,
+  listManagedPromotionSlides,
+} from "@/lib/promotions/events";
 import { SITE_NAME } from "@/lib/site";
 
 export const dynamic = "force-dynamic";
@@ -33,7 +36,16 @@ export default async function AdminAdvertisementPage({
 }) {
   const params = (await searchParams) ?? {};
   const message = statusMessage(params.status);
-  const slides = await listManagedPromotionSlides({ includeInactive: true });
+  const [slides, eventCampaigns] = await Promise.all([
+    listManagedPromotionSlides({ includeInactive: true }),
+    listManagedEventCampaigns({ includeInactive: false }),
+  ]);
+  const eventPageOptions = eventCampaigns
+    .filter((campaign) => campaign.isActive)
+    .map((campaign) => ({
+      href: campaign.pagePath,
+      label: `${campaign.title} (${campaign.pagePath})`,
+    }));
   const activeSlides = slides.filter((slide) => slide.isActive).length;
   const databaseSlides = slides.filter((slide) => slide.source === "database").length;
   const catalogSlides = slides.filter((slide) => slide.source === "catalog").length;
@@ -63,7 +75,11 @@ export default async function AdminAdvertisementPage({
             title="캐러셀 편집기"
             description="메인 미리보기와 카드별 상세 편집을 같은 워크스페이스에서 다룹니다."
           />
-          <PromotionCarouselEditor initialSlides={slides} saveAction={savePromotionSlidesAction} />
+          <PromotionCarouselEditor
+            initialSlides={slides}
+            eventPageOptions={eventPageOptions}
+            saveAction={savePromotionSlidesAction}
+          />
         </section>
       </div>
     </AdminShell>

--- a/src/app/admin/(protected)/event/[slug]/page.tsx
+++ b/src/app/admin/(protected)/event/[slug]/page.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/app/admin/(protected)/_actions/promotion-actions";
 import { getEventPageDefinition } from "@/lib/event-pages";
 import { PROMOTION_AUDIENCE_OPTIONS } from "@/lib/promotions/catalog";
+import {
+  getEventRewardAdminOverview,
+  type EventRewardAdminMemberRow,
+  type EventRewardAdminOverview,
+} from "@/lib/promotions/event-rewards";
 import { listManagedEventCampaigns, type ManagedEventCampaign } from "@/lib/promotions/events";
 
 export const dynamic = "force-dynamic";
@@ -79,6 +84,146 @@ function getEventState(campaign: ManagedEventCampaign | null) {
   };
 }
 
+function rewardConditionLabel(
+  row: EventRewardAdminMemberRow,
+  key: "signup" | "mm" | "push" | "marketing" | "review",
+) {
+  const condition = row.conditions.find((item) => item.key === key);
+  if (key === "review") {
+    return `${condition?.currentCount ?? 0}개`;
+  }
+  return condition?.status === "received" ? "완료" : "-";
+}
+
+function RewardStatusPill({
+  value,
+  muted = false,
+}: {
+  value: string;
+  muted?: boolean;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
+        value === "완료" && !muted
+          ? "border-primary/20 bg-primary-soft text-primary"
+          : "border-border/70 bg-surface-inset text-muted-foreground"
+      }`}
+    >
+      {value}
+    </span>
+  );
+}
+
+function SignupRewardOverviewSection({
+  overview,
+}: {
+  overview: EventRewardAdminOverview;
+}) {
+  const conditionStats = [
+    { label: "회원가입", value: `${overview.conditionCounts.signup ?? 0}명` },
+    { label: "MM 알림", value: `${overview.conditionCounts.mm ?? 0}명` },
+    { label: "푸시", value: `${overview.conditionCounts.push ?? 0}명` },
+    { label: "마케팅", value: `${overview.conditionCounts.marketing ?? 0}명` },
+  ];
+
+  return (
+    <section className="grid gap-5" aria-label="추첨권 현황">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="ui-kicker">Rewards</p>
+          <h3 className="mt-2 text-xl font-semibold text-foreground">
+            추첨권 현황
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            이벤트 종료 전 가입자는 회원가입 추첨권 1장을 완료 처리합니다.
+          </p>
+        </div>
+        <Button href="/admin/event/signup-reward/rewards/export" variant="secondary">
+          CSV 내보내기
+        </Button>
+      </div>
+
+      <StatsRow
+        items={[
+          { label: "대상 회원", value: `${overview.memberCount.toLocaleString()}명`, hint: "전체 회원" },
+          { label: "총 추첨권", value: `${overview.totalTickets.toLocaleString()}장`, hint: "현재 조건 기준" },
+          { label: "리뷰 인정", value: `${overview.reviewCount.toLocaleString()}개`, hint: "이벤트 기간 visible 리뷰" },
+          { label: "가입 완료", value: `${(overview.conditionCounts.signup ?? 0).toLocaleString()}명`, hint: "종료 전 가입자" },
+        ]}
+        minItemWidth="13rem"
+      />
+
+      <Card tone="muted" className="grid gap-3">
+        <div className="flex flex-wrap gap-2">
+          {conditionStats.map((item) => (
+            <span
+              key={item.label}
+              className="rounded-full border border-border/70 bg-surface px-2.5 py-1 text-xs font-semibold text-muted-foreground"
+            >
+              {item.label} · {item.value}
+            </span>
+          ))}
+        </div>
+      </Card>
+
+      <Card tone="elevated" padding="none" className="overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-[960px] w-full text-left text-sm">
+            <thead className="border-b border-border bg-surface-inset text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">회원</th>
+                <th className="px-4 py-3">기수/캠퍼스</th>
+                <th className="px-4 py-3 text-right">총 추첨권</th>
+                <th className="px-4 py-3">signup</th>
+                <th className="px-4 py-3">mm</th>
+                <th className="px-4 py-3">push</th>
+                <th className="px-4 py-3">marketing</th>
+                <th className="px-4 py-3">review</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/70">
+              {overview.members.map((member) => (
+                <tr key={member.id} className="align-middle">
+                  <td className="px-4 py-3">
+                    <p className="font-semibold text-foreground">
+                      {member.displayName || member.mmUsername}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {member.mmUsername}
+                    </p>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {member.year}기 · {member.campus || "-"}
+                  </td>
+                  <td className="px-4 py-3 text-right text-base font-semibold text-foreground">
+                    {member.totalTickets.toLocaleString()}장
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "signup")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "mm")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "push")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "marketing")} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <RewardStatusPill value={rewardConditionLabel(member, "review")} muted />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </section>
+  );
+}
+
 export default async function AdminEventDetailPage({
   params,
   searchParams,
@@ -95,9 +240,12 @@ export default async function AdminEventDetailPage({
 
   const campaigns = await listManagedEventCampaigns({ includeInactive: true });
   const registration = campaigns.find((campaign) => campaign.slug === slug) ?? null;
+  const campaign = registration ?? definition;
   const isRegistered = registration?.source === "database" && Boolean(registration.id);
   const state = getEventState(registration);
   const message = statusMessage(paramsData.status);
+  const rewardOverview =
+    slug === "signup-reward" ? await getEventRewardAdminOverview(campaign) : null;
   const targetLabel =
     registration?.targetAudiences?.map(
       (audience) => PROMOTION_AUDIENCE_OPTIONS.find((option) => option.key === audience)?.label ?? audience,
@@ -230,6 +378,10 @@ export default async function AdminEventDetailPage({
             </ul>
           </Card>
         </div>
+
+        {rewardOverview ? (
+          <SignupRewardOverviewSection overview={rewardOverview} />
+        ) : null}
       </div>
     </AdminShell>
   );

--- a/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
+++ b/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { getEventPageDefinition } from "@/lib/event-pages";
+import {
+  createEventRewardCsv,
+  getEventRewardAdminOverview,
+} from "@/lib/promotions/event-rewards";
+import { getManagedEventCampaign } from "@/lib/promotions/events";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  await requireAdmin();
+
+  const definition = getEventPageDefinition("signup-reward");
+  if (!definition) {
+    return NextResponse.json({ message: "이벤트 정의를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const campaign = (await getManagedEventCampaign("signup-reward")) ?? definition;
+  const overview = await getEventRewardAdminOverview(campaign);
+  const csv = createEventRewardCsv(overview);
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="signup-reward-rewards.csv"',
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
+++ b/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
@@ -13,6 +13,7 @@ import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import FormMessage from "@/components/ui/FormMessage";
 import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
 import Textarea from "@/components/ui/Textarea";
 import PromotionCarousel from "@/components/promotions/PromotionCarousel";
 import MediaCropModal from "@/components/admin/partner-media-editor/MediaCropModal";
@@ -45,6 +46,11 @@ type SlideDraft = {
 type PendingCrop = {
   slideId: string;
   sourceUrl: string;
+};
+
+export type PromotionEventPageOption = {
+  href: string;
+  label: string;
 };
 
 function createPlaceholderImage(title: string) {
@@ -148,9 +154,11 @@ function toggleAudience(
 
 export default function PromotionCarouselEditor({
   initialSlides,
+  eventPageOptions,
   saveAction,
 }: {
   initialSlides: ManagedPromotionSlide[];
+  eventPageOptions: PromotionEventPageOption[];
   saveAction: (formData: FormData) => void | Promise<void>;
 }) {
   const [slides, setSlides] = useState<SlideDraft[]>(
@@ -177,7 +185,7 @@ export default function PromotionCarouselEditor({
   const previewSlides = useMemo(
     () =>
       slides
-        .filter((slide) => slide.imageSrc)
+        .filter((slide) => slide.isActive && slide.imageSrc)
         .map((slide) => ({
           id: slide.id,
           title: slide.title || "광고 카드",
@@ -398,7 +406,13 @@ export default function PromotionCarouselEditor({
             홈에서 보기
           </Button>
         </div>
-        <PromotionCarousel slides={previewSlides} className="mt-0" />
+        {previewSlides.length > 0 ? (
+          <PromotionCarousel slides={previewSlides} className="mt-0" />
+        ) : (
+          <div className="rounded-overlay border border-dashed border-border bg-surface-inset px-4 py-10 text-center text-sm font-medium text-muted-foreground">
+            활성 광고 카드가 없습니다. 카드를 활성화하면 실제 홈 배너와 같은 기준으로 미리볼 수 있습니다.
+          </div>
+        )}
       </Card>
 
       <form ref={formRef} action={saveAction} className="grid gap-6">
@@ -571,6 +585,35 @@ export default function PromotionCarouselEditor({
                   </div>
 
                   <div className="grid gap-4 rounded-panel border border-border/70 bg-surface-inset p-4">
+                    <div className="grid gap-2">
+                      <label className="text-sm font-medium text-foreground" htmlFor={`event-page-${slide.id}`}>
+                        이벤트 페이지에서 선택
+                      </label>
+                      <Select
+                        id={`event-page-${slide.id}`}
+                        value={eventPageOptions.some((option) => option.href === slide.href) ? slide.href : ""}
+                        disabled={!editable || eventPageOptions.length === 0}
+                        onChange={(event) => {
+                          const href = event.target.value;
+                          if (!href) {
+                            return;
+                          }
+                          updateSlide(slide.id, (current) => ({ ...current, href }));
+                        }}
+                      >
+                        <option value="">
+                          {eventPageOptions.length > 0
+                            ? "활성 이벤트 페이지 선택"
+                            : "활성 이벤트 페이지 없음"}
+                        </option>
+                        {eventPageOptions.map((option) => (
+                          <option key={option.href} value={option.href}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+
                     <label className="grid gap-2 text-sm font-medium text-foreground">
                       연결 페이지
                       <Input
@@ -582,6 +625,9 @@ export default function PromotionCarouselEditor({
                         disabled={!editable}
                         className={hrefInvalid ? "border-danger/40 bg-danger/5 focus:border-danger" : undefined}
                       />
+                      <span className="text-xs font-normal leading-5 text-muted-foreground">
+                        직접 입력하거나 위의 활성 이벤트 페이지 목록에서 선택할 수 있습니다.
+                      </span>
                     </label>
 
                     <div className="grid gap-3">

--- a/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
+++ b/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
@@ -18,7 +18,11 @@ import Textarea from "@/components/ui/Textarea";
 import PromotionCarousel from "@/components/promotions/PromotionCarousel";
 import MediaCropModal from "@/components/admin/partner-media-editor/MediaCropModal";
 import { CAMPUS_DIRECTORY, type CampusSlug } from "@/lib/campuses";
-import { isImageFile, setInputFiles } from "@/components/admin/partner-media-editor/utils";
+import {
+  createWebpFile,
+  isImageFile,
+  setInputFiles,
+} from "@/components/admin/partner-media-editor/utils";
 import {
   DEFAULT_PROMOTION_AUDIENCES,
   PROMOTION_AUDIENCE_OPTIONS,
@@ -28,6 +32,11 @@ import type { ManagedPromotionSlide } from "@/lib/promotions/events";
 import { cn } from "@/lib/cn";
 
 const PROMOTION_ASPECT_RATIO = 21 / 9;
+const PROMOTION_ASPECT_RATIO_TOLERANCE = 0.01;
+const PROMOTION_OUTPUT_SIZE = {
+  width: 2100,
+  height: 900,
+} as const;
 
 type SlideDraft = {
   id: string;
@@ -110,6 +119,59 @@ function toDraftSlide(slide: ManagedPromotionSlide): SlideDraft {
 
 function getFileInputName(id: string) {
   return `slide_image_${id}`;
+}
+
+function loadImageElement(sourceUrl: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new window.Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("이미지를 불러오지 못했습니다."));
+    image.src = sourceUrl;
+  });
+}
+
+function isPromotionAspectRatio(width: number, height: number) {
+  if (width <= 0 || height <= 0) {
+    return false;
+  }
+  return Math.abs(width / height - PROMOTION_ASPECT_RATIO) <= PROMOTION_ASPECT_RATIO_TOLERANCE;
+}
+
+async function createPromotionWebpFileFromImage(image: HTMLImageElement, outputName: string) {
+  const canvas = document.createElement("canvas");
+  canvas.width = PROMOTION_OUTPUT_SIZE.width;
+  canvas.height = PROMOTION_OUTPUT_SIZE.height;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("이미지 처리에 실패했습니다.");
+  }
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+  ctx.drawImage(
+    image,
+    0,
+    0,
+    image.naturalWidth,
+    image.naturalHeight,
+    0,
+    0,
+    PROMOTION_OUTPUT_SIZE.width,
+    PROMOTION_OUTPUT_SIZE.height,
+  );
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((nextBlob) => {
+      if (!nextBlob) {
+        reject(new Error("이미지 변환에 실패했습니다."));
+        return;
+      }
+      resolve(nextBlob);
+    }, "image/webp", 0.78);
+  });
+
+  return createWebpFile(blob, outputName);
 }
 
 function SlideBadge({
@@ -334,7 +396,7 @@ export default function PromotionCarouselEditor({
     });
   }
 
-  function onFileChange(id: string, file: File | null) {
+  async function onFileChange(id: string, file: File | null) {
     if (!file) {
       return;
     }
@@ -343,7 +405,32 @@ export default function PromotionCarouselEditor({
       return;
     }
     const sourceUrl = URL.createObjectURL(file);
-    setPendingCrop({ slideId: id, sourceUrl });
+    try {
+      const image = await loadImageElement(sourceUrl);
+      if (isPromotionAspectRatio(image.naturalWidth, image.naturalHeight)) {
+        const normalizedFile = await createPromotionWebpFileFromImage(image, `${id}-slide.webp`);
+        const nextUrl = URL.createObjectURL(normalizedFile);
+        const input = fileInputRefs.current.get(id) ?? null;
+        setInputFiles(input, [normalizedFile]);
+        updateSlide(id, (slide) => ({
+          ...slide,
+          imageSrc: nextUrl,
+          hasImageFile: true,
+          imageAlt: slide.imageAlt || slide.title || "광고 카드 이미지",
+        }));
+        URL.revokeObjectURL(sourceUrl);
+        setError(null);
+        return;
+      }
+      setPendingCrop({ slideId: id, sourceUrl });
+    } catch {
+      URL.revokeObjectURL(sourceUrl);
+      const input = fileInputRefs.current.get(id) ?? null;
+      if (input) {
+        input.value = "";
+      }
+      setError("이미지를 불러올 수 없습니다. 다른 파일을 사용해 주세요.");
+    }
   }
 
   function applyCroppedImage(file: File) {
@@ -547,7 +634,7 @@ export default function PromotionCarouselEditor({
                       <img
                         src={previewSrc}
                         alt={slide.imageAlt || slide.title || "광고 카드 이미지"}
-                        className="h-full w-full object-cover"
+                        className="h-full w-full object-contain"
                         draggable={false}
                       />
                     </div>
@@ -576,11 +663,13 @@ export default function PromotionCarouselEditor({
                         accept="image/*"
                         name={getFileInputName(slide.id)}
                         className="hidden"
-                        onChange={(event) => onFileChange(slide.id, event.target.files?.[0] ?? null)}
+                        onChange={(event) => {
+                          void onFileChange(slide.id, event.target.files?.[0] ?? null);
+                        }}
                       />
                     </div>
                     <p className="text-xs leading-6 text-muted-foreground">
-                      21:9 이미지를 업로드한 뒤 팝업에서 위치를 조정하면 캐러셀에서 즉시 반영됩니다.
+                      21:9 이미지는 원본 그대로 반영하고, 비율이 다르면 팝업에서 위치를 조정합니다.
                     </p>
                   </div>
 

--- a/src/components/events/EventLanding.tsx
+++ b/src/components/events/EventLanding.tsx
@@ -24,16 +24,18 @@ const conditionIcons: Record<EventConditionKey, typeof UserPlusIcon> = {
 export default function EventLanding({
   campaign,
   summary,
+  showHeroImage = true,
 }: {
   campaign: EventCampaign;
   summary: EventRewardSummary;
+  showHeroImage?: boolean;
 }) {
   const summaryMap = new Map(summary.conditions.map((condition) => [condition.key, condition]));
 
   return (
     <div className="space-y-5">
       <Card tone="hero" padding="none" className="overflow-hidden">
-        <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_24rem]">
+        <div className={showHeroImage ? "grid gap-0 lg:grid-cols-[minmax(0,1fr)_24rem]" : "grid gap-0"}>
           <div className="p-6 sm:p-8 lg:p-10">
             <p className="text-sm font-semibold uppercase tracking-[0.22em] opacity-80">
               Event
@@ -46,16 +48,18 @@ export default function EventLanding({
             </p>
             <p className="mt-4 text-sm font-semibold opacity-90">{campaign.periodLabel}</p>
           </div>
-          <div className="relative min-h-48 border-t border-white/10 bg-black/15 lg:border-l lg:border-t-0">
-            <Image
-              src={campaign.heroImageSrc}
-              alt={campaign.heroImageAlt}
-              fill
-              priority
-              sizes="(min-width: 1024px) 384px, calc(100vw - 32px)"
-              className="object-cover"
-            />
-          </div>
+          {showHeroImage ? (
+            <div className="relative min-h-48 border-t border-white/10 bg-black/15 lg:border-l lg:border-t-0">
+              <Image
+                src={campaign.heroImageSrc}
+                alt={campaign.heroImageAlt}
+                fill
+                priority
+                sizes="(min-width: 1024px) 384px, calc(100vw - 32px)"
+                className="object-cover"
+              />
+            </div>
+          ) : null}
         </div>
       </Card>
 

--- a/src/components/promotions/PromotionCarousel.tsx
+++ b/src/components/promotions/PromotionCarousel.tsx
@@ -130,7 +130,7 @@ export default function PromotionCarousel({
                   <img
                     src={slide.imageSrc}
                     alt={slide.imageAlt}
-                    className="h-full w-full object-cover"
+                    className="h-full w-full object-contain"
                     draggable={false}
                   />
                 ) : (
@@ -141,7 +141,7 @@ export default function PromotionCarousel({
                     sizes="(min-width: 1280px) 1084px, calc(100vw - 32px)"
                     priority={index === 0}
                     unoptimized={isRemoteImageSrc(slide.imageSrc)}
-                    className="object-cover"
+                    className="object-contain"
                   />
                 )}
               </div>

--- a/src/components/push/PushSettingsCard.tsx
+++ b/src/components/push/PushSettingsCard.tsx
@@ -138,17 +138,17 @@ export default function PushSettingsCard(props: PushSettingsCardProps) {
                 <span className="text-sm font-medium text-foreground">푸시</span>
                 <span className="flex items-center gap-3">
                   <span
-                    className={controller.preferences.enabled
+                    className={controller.pushEnabled
                       ? "min-w-10 text-right text-xs font-semibold text-emerald-600 dark:text-emerald-300"
                       : "min-w-10 text-right text-xs font-semibold text-muted-foreground"}
                   >
-                    {controller.preferences.enabled ? "켜짐" : "꺼짐"}
+                    {controller.pushEnabled ? "켜짐" : "꺼짐"}
                   </span>
                   <span className="relative inline-flex items-center">
                     <input
                       type="checkbox"
                       className="peer sr-only"
-                      checked={controller.preferences.enabled}
+                      checked={controller.pushEnabled}
                       disabled={controller.hasPendingAction}
                       onChange={(event) => {
                         void controller.updateChannelPreference(
@@ -162,7 +162,7 @@ export default function PushSettingsCard(props: PushSettingsCardProps) {
                   </span>
                 </span>
               </label>
-              {controller.preferences.enabled ? (
+              {controller.pushEnabled ? (
                 <div className="grid gap-2 border-t border-border/70 pt-3">
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">

--- a/src/components/push/push-settings/status.ts
+++ b/src/components/push/push-settings/status.ts
@@ -6,10 +6,12 @@ export function derivePushSettingsStatus(params: {
   iosNeedsInstall: boolean;
   isReceivingOnThisDevice: boolean;
   accountEnabled: boolean;
+  hasAnyPushDevice: boolean;
 }): PushSettingsStatus | null {
   const {
     accountEnabled,
     configured,
+    hasAnyPushDevice,
     iosNeedsInstall,
     isReceivingOnThisDevice,
     supported,
@@ -26,7 +28,7 @@ export function derivePushSettingsStatus(params: {
   if (isReceivingOnThisDevice) {
     return { label: "알림 수신 중", tone: "success" };
   }
-  if (accountEnabled) {
+  if (accountEnabled && hasAnyPushDevice) {
     return { label: "다른 기기에서만 수신 중", tone: "muted" };
   }
   return null;

--- a/src/components/push/push-settings/usePushSettingsController.ts
+++ b/src/components/push/push-settings/usePushSettingsController.ts
@@ -69,7 +69,8 @@ export function usePushSettingsController({
 
   const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
   const deviceEnabled = deviceState.hasSubscription;
-  const accountEnabled = preferences.enabled;
+  const hasAnyPushDevice = devices.length > 0;
+  const accountEnabled = preferences.enabled && hasAnyPushDevice;
   const isReceivingOnThisDevice = accountEnabled && deviceEnabled;
   const canControlPush =
     configured && deviceState.supported && !deviceState.iosNeedsInstall;
@@ -82,12 +83,14 @@ export function usePushSettingsController({
         iosNeedsInstall: deviceState.iosNeedsInstall,
         isReceivingOnThisDevice,
         accountEnabled,
+        hasAnyPushDevice,
       }),
     [
       accountEnabled,
       configured,
       deviceState.iosNeedsInstall,
       deviceState.supported,
+      hasAnyPushDevice,
       isReceivingOnThisDevice,
     ],
   );
@@ -278,6 +281,11 @@ export function usePushSettingsController({
     key: ChannelPreferenceKey,
     nextValue: boolean,
   ) {
+    if (key === "enabled" && nextValue && devices.length === 0) {
+      await handleSubscribe();
+      return;
+    }
+
     if (key === "enabled" && !nextValue) {
       await handleUnsubscribeAll({ confirm: false });
       return;
@@ -340,6 +348,7 @@ export function usePushSettingsController({
     vapidPublicKey,
     deviceEnabled,
     accountEnabled,
+    pushEnabled: accountEnabled,
     isReceivingOnThisDevice,
     canControlPush,
     hasPendingAction,

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -1,5 +1,6 @@
 import { getPolicyDocumentByKind, recordMarketingPolicyConsent } from "@/lib/policy-documents";
 import {
+  countActivePushSubscriptions,
   DEFAULT_PUSH_PREFERENCES,
   getMemberPushPreferences,
   upsertMemberPushPreferences,
@@ -101,6 +102,9 @@ export function deactivateMockPushDevice(params: {
       ),
     );
   }
+  if ((mockPushDeviceStore.get(params.memberId) ?? []).length === 0) {
+    return updateMemberNotificationPreferences(params.memberId, { enabled: false });
+  }
   return getMemberNotificationPreferences(params.memberId);
 }
 
@@ -111,10 +115,20 @@ export function deactivateAllMockPushDevices(memberId: string) {
 
 export async function getMemberNotificationPreferences(memberId: string) {
   if (useMockPreferences) {
-    return getMockPreferences(memberId);
+    const preferences = getMockPreferences(memberId);
+    return {
+      ...preferences,
+      enabled:
+        preferences.enabled && (mockPushDeviceStore.get(memberId) ?? []).length > 0,
+    };
   }
   const supabase = getSupabaseAdminClient();
-  const [preferences, activeMarketingPolicy, memberResult] = await Promise.all([
+  const [
+    preferences,
+    activeMarketingPolicy,
+    memberResult,
+    activePushSubscriptionCount,
+  ] = await Promise.all([
     getMemberPushPreferences(memberId),
     getPolicyDocumentByKind("marketing").catch(() => null),
     supabase
@@ -122,6 +136,7 @@ export async function getMemberNotificationPreferences(memberId: string) {
       .select("marketing_policy_version")
       .eq("id", memberId)
       .maybeSingle(),
+    countActivePushSubscriptions(memberId),
   ]);
 
   if (memberResult.error) {
@@ -130,6 +145,7 @@ export async function getMemberNotificationPreferences(memberId: string) {
 
   return {
     ...preferences,
+    enabled: preferences.enabled && activePushSubscriptionCount > 0,
     marketingEnabled: Boolean(
       activeMarketingPolicy &&
         memberResult.data?.marketing_policy_version === activeMarketingPolicy.version,
@@ -146,15 +162,25 @@ export async function updateMemberNotificationPreferences(
   },
 ) {
   if (useMockPreferences) {
+    const current = getMockPreferences(memberId);
+    const hasPushDevice = (mockPushDeviceStore.get(memberId) ?? []).length > 0;
     const next = {
-      ...getMockPreferences(memberId),
+      ...current,
       ...value,
+      enabled: (value.enabled ?? current.enabled) && hasPushDevice,
     };
     mockPreferenceStore.set(memberId, next);
     return next;
   }
 
-  const preferences = await upsertMemberPushPreferences(memberId, value);
+  const activePushSubscriptionCount = await countActivePushSubscriptions(memberId);
+  const currentPreferences = await getMemberPushPreferences(memberId);
+  const preferences = await upsertMemberPushPreferences(memberId, {
+    ...value,
+    enabled:
+      (value.enabled ?? currentPreferences.enabled) &&
+      activePushSubscriptionCount > 0,
+  });
   const activeMarketingPolicy = await getPolicyDocumentByKind("marketing");
 
   await recordMarketingPolicyConsent({

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -1,5 +1,8 @@
 import { getMemberNotificationPreferences } from "@/lib/notification-preferences";
 import { fetchMemberVisibleReviewCountInRange } from "@/lib/partner-counts";
+import { collectPagedRows } from "@/lib/log-insights/paging";
+import { getPolicyDocumentByKind } from "@/lib/policy-documents";
+import { getPushPreferencesOrDefault } from "@/lib/push";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import type { EventCampaign, EventConditionKey } from "@/lib/promotions/catalog";
 
@@ -28,16 +31,113 @@ type MemberRewardSnapshot = {
   reviewCount: number;
 };
 
-function isWithinCampaign(value: string | null, campaign: EventCampaign) {
+export type EventRewardAdminMemberInput = {
+  id: string;
+  displayName: string | null;
+  mmUsername: string;
+  year: number;
+  campus: string | null;
+  createdAt: string | null;
+  preferences: MemberRewardSnapshot["preferences"];
+  reviewCount: number;
+};
+
+export type EventRewardAdminMemberRow = EventRewardAdminMemberInput & {
+  totalTickets: number;
+  conditions: EventRewardConditionSummary[];
+};
+
+export type EventRewardAdminOverview = {
+  memberCount: number;
+  totalTickets: number;
+  reviewCount: number;
+  conditionCounts: Record<EventConditionKey, number>;
+  members: EventRewardAdminMemberRow[];
+};
+
+type MemberRow = {
+  id: string;
+  display_name: string | null;
+  mm_username: string | null;
+  year: number | null;
+  campus: string | null;
+  marketing_policy_version: number | null;
+  created_at: string | null;
+};
+
+type PreferenceRow = {
+  member_id: string | null;
+  enabled: boolean | null;
+  mm_enabled: boolean | null;
+};
+
+type ReviewRow = {
+  member_id: string | null;
+};
+
+function isJoinedByCampaignEnd(value: string | null, campaign: EventCampaign) {
   if (!value) {
     return false;
   }
   const time = new Date(value).getTime();
-  return (
-    Number.isFinite(time) &&
-    time >= new Date(campaign.startsAt).getTime() &&
-    time <= new Date(campaign.endsAt).getTime()
-  );
+  return Number.isFinite(time) && time <= new Date(campaign.endsAt).getTime();
+}
+
+export function calculateEventRewardConditions(
+  campaign: EventCampaign,
+  snapshot: MemberRewardSnapshot,
+): EventRewardConditionSummary[] {
+  return campaign.conditions.map<EventRewardConditionSummary>((condition) => {
+    if (condition.key === "signup") {
+      const received = isJoinedByCampaignEnd(snapshot.createdAt, campaign);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "mm") {
+      const received = Boolean(snapshot.preferences?.mmEnabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "push") {
+      const received = Boolean(snapshot.preferences?.enabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    if (condition.key === "marketing") {
+      const received = Boolean(snapshot.preferences?.marketingEnabled);
+      return {
+        key: condition.key,
+        status: received ? "received" : "missing",
+        earnedTickets: received ? condition.tickets : 0,
+      };
+    }
+
+    const reviewCount = snapshot.reviewCount;
+    return {
+      key: condition.key,
+      status: reviewCount > 0 ? "received" : "missing",
+      earnedTickets: reviewCount * condition.tickets,
+      currentCount: reviewCount,
+    };
+  });
+}
+
+export function sumEventRewardTickets(
+  conditions: readonly EventRewardConditionSummary[],
+) {
+  return conditions.reduce((sum, condition) => sum + condition.earnedTickets, 0);
 }
 
 async function getMemberRewardSnapshot(
@@ -83,55 +183,206 @@ export async function getEventRewardSummary(params: {
 
   const snapshot = await getMemberRewardSnapshot(params.memberId, params.campaign);
 
-  const conditions = params.campaign.conditions.map<EventRewardConditionSummary>((condition) => {
-    if (condition.key === "signup") {
-      const received = isWithinCampaign(snapshot.createdAt, params.campaign);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+  const conditions = calculateEventRewardConditions(params.campaign, snapshot);
 
-    if (condition.key === "mm") {
-      const received = Boolean(snapshot.preferences?.mmEnabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+  return {
+    authenticated: true,
+    totalTickets: sumEventRewardTickets(conditions),
+    conditions,
+  };
+}
 
-    if (condition.key === "push") {
-      const received = Boolean(snapshot.preferences?.enabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
-    }
+export function buildEventRewardAdminOverview(
+  campaign: EventCampaign,
+  members: readonly EventRewardAdminMemberInput[],
+): EventRewardAdminOverview {
+  const conditionCounts = Object.fromEntries(
+    campaign.conditions.map((condition) => [condition.key, 0]),
+  ) as Record<EventConditionKey, number>;
 
-    if (condition.key === "marketing") {
-      const received = Boolean(snapshot.preferences?.marketingEnabled);
-      return {
-        key: condition.key,
-        status: received ? "received" : "missing",
-        earnedTickets: received ? condition.tickets : 0,
-      };
+  const rows = members.map<EventRewardAdminMemberRow>((member) => {
+    const conditions = calculateEventRewardConditions(campaign, {
+      createdAt: member.createdAt,
+      preferences: member.preferences,
+      reviewCount: member.reviewCount,
+    });
+    for (const condition of conditions) {
+      if (condition.status === "received") {
+        conditionCounts[condition.key] = (conditionCounts[condition.key] ?? 0) + 1;
+      }
     }
-
-    const reviewCount = snapshot.reviewCount;
     return {
-      key: condition.key,
-      status: reviewCount > 0 ? "received" : "missing",
-      earnedTickets: reviewCount * condition.tickets,
-      currentCount: reviewCount,
+      ...member,
+      totalTickets: sumEventRewardTickets(conditions),
+      conditions,
     };
   });
 
   return {
-    authenticated: true,
-    totalTickets: conditions.reduce((sum, condition) => sum + condition.earnedTickets, 0),
-    conditions,
+    memberCount: rows.length,
+    totalTickets: rows.reduce((sum, row) => sum + row.totalTickets, 0),
+    reviewCount: rows.reduce((sum, row) => sum + row.reviewCount, 0),
+    conditionCounts,
+    members: rows.sort((a, b) => {
+      if (b.totalTickets !== a.totalTickets) {
+        return b.totalTickets - a.totalTickets;
+      }
+      return (a.displayName ?? a.mmUsername).localeCompare(
+        b.displayName ?? b.mmUsername,
+        "ko",
+      );
+    }),
   };
+}
+
+function csvCell(value: string | number | null | undefined) {
+  const text = String(value ?? "");
+  return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function conditionStatusLabel(
+  row: EventRewardAdminMemberRow,
+  key: EventConditionKey,
+) {
+  const condition = row.conditions.find((item) => item.key === key);
+  if (key === "review") {
+    return String(condition?.currentCount ?? 0);
+  }
+  return condition?.status === "received" ? "완료" : "미완료";
+}
+
+export function createEventRewardCsv(overview: EventRewardAdminOverview) {
+  const headers = [
+    "이름",
+    "MM ID",
+    "기수",
+    "캠퍼스",
+    "총 추첨권",
+    "signup",
+    "mm",
+    "push",
+    "marketing",
+    "review",
+  ];
+  const rows = overview.members.map((member) => [
+    member.displayName ?? "",
+    member.mmUsername,
+    member.year,
+    member.campus ?? "",
+    member.totalTickets,
+    conditionStatusLabel(member, "signup"),
+    conditionStatusLabel(member, "mm"),
+    conditionStatusLabel(member, "push"),
+    conditionStatusLabel(member, "marketing"),
+    conditionStatusLabel(member, "review"),
+  ]);
+
+  return `\uFEFF${[headers, ...rows]
+    .map((row) => row.map((value) => csvCell(value)).join(","))
+    .join("\n")}`;
+}
+
+function normalizePreferences(params: {
+  row?: PreferenceRow | null;
+  marketingEnabled: boolean;
+}): MemberRewardSnapshot["preferences"] {
+  const preferences = getPushPreferencesOrDefault(
+    params.row
+      ? {
+          enabled: params.row.enabled ?? undefined,
+          mmEnabled: params.row.mm_enabled ?? undefined,
+        }
+      : null,
+  );
+  return {
+    enabled: preferences.enabled,
+    mmEnabled: preferences.mmEnabled,
+    marketingEnabled: params.marketingEnabled,
+  };
+}
+
+async function fetchAllEventMembers(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+) {
+  const result = await collectPagedRows<MemberRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("members")
+      .select("id,display_name,mm_username,year,campus,marketing_policy_version,created_at")
+      .order("year", { ascending: false })
+      .order("display_name", { ascending: true })
+      .range(from, to);
+    return { rows: (data ?? []) as MemberRow[], error: Boolean(error) };
+  });
+  return result.rows;
+}
+
+async function fetchAllEventPreferences(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+) {
+  const result = await collectPagedRows<PreferenceRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("push_preferences")
+      .select("member_id,enabled,mm_enabled")
+      .range(from, to);
+    return { rows: (data ?? []) as PreferenceRow[], error: Boolean(error) };
+  });
+  return result.rows;
+}
+
+async function fetchAllEventReviewCounts(
+  supabase: ReturnType<typeof getSupabaseAdminClient>,
+  campaign: EventCampaign,
+) {
+  const result = await collectPagedRows<ReviewRow>(null, async (from, to) => {
+    const { data, error } = await supabase
+      .from("partner_reviews")
+      .select("member_id")
+      .gte("created_at", campaign.startsAt)
+      .lte("created_at", campaign.endsAt)
+      .is("deleted_at", null)
+      .is("hidden_at", null)
+      .range(from, to);
+    return { rows: (data ?? []) as ReviewRow[], error: Boolean(error) };
+  });
+  const counts = new Map<string, number>();
+  for (const row of result.rows) {
+    if (!row.member_id) {
+      continue;
+    }
+    counts.set(row.member_id, (counts.get(row.member_id) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export async function getEventRewardAdminOverview(campaign: EventCampaign) {
+  const supabase = getSupabaseAdminClient();
+  const [members, preferences, reviewCounts] = await Promise.all([
+    fetchAllEventMembers(supabase),
+    fetchAllEventPreferences(supabase),
+    fetchAllEventReviewCounts(supabase, campaign),
+  ]);
+  const activeMarketingPolicy = await getPolicyDocumentByKind("marketing").catch(
+    () => null,
+  );
+  const preferenceMap = new Map(preferences.map((row) => [row.member_id ?? "", row]));
+
+  return buildEventRewardAdminOverview(
+    campaign,
+    members.map((member) => ({
+      id: member.id,
+      displayName: member.display_name,
+      mmUsername: member.mm_username ?? "",
+      year: member.year ?? 0,
+      campus: member.campus,
+      createdAt: member.created_at,
+      preferences: normalizePreferences({
+        row: preferenceMap.get(member.id),
+        marketingEnabled: Boolean(
+          activeMarketingPolicy &&
+            member.marketing_policy_version === activeMarketingPolicy.version,
+        ),
+      }),
+      reviewCount: reviewCounts.get(member.id) ?? 0,
+    })),
+  );
 }

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -75,6 +75,14 @@ type ReviewRow = {
   member_id: string | null;
 };
 
+function assertEventRewardQuerySucceeded(error: unknown, label: string) {
+  if (!error) {
+    return;
+  }
+  const message = error instanceof Error && error.message ? error.message : String(error);
+  throw new Error(`이벤트 추첨권 현황 조회에 실패했습니다. (${label}: ${message})`);
+}
+
 function isJoinedByCampaignEnd(value: string | null, campaign: EventCampaign) {
   if (!value) {
     return false;
@@ -310,8 +318,10 @@ async function fetchAllEventMembers(
       .select("id,display_name,mm_username,year,campus,marketing_policy_version,created_at")
       .order("year", { ascending: false })
       .order("display_name", { ascending: true })
+      .order("id", { ascending: true })
       .range(from, to);
-    return { rows: (data ?? []) as MemberRow[], error: Boolean(error) };
+    assertEventRewardQuerySucceeded(error, "members");
+    return { rows: (data ?? []) as MemberRow[], error: false };
   });
   return result.rows;
 }
@@ -323,8 +333,10 @@ async function fetchAllEventPreferences(
     const { data, error } = await supabase
       .from("push_preferences")
       .select("member_id,enabled,mm_enabled")
+      .order("member_id", { ascending: true })
       .range(from, to);
-    return { rows: (data ?? []) as PreferenceRow[], error: Boolean(error) };
+    assertEventRewardQuerySucceeded(error, "push_preferences");
+    return { rows: (data ?? []) as PreferenceRow[], error: false };
   });
   return result.rows;
 }
@@ -341,8 +353,12 @@ async function fetchAllEventReviewCounts(
       .lte("created_at", campaign.endsAt)
       .is("deleted_at", null)
       .is("hidden_at", null)
+      .order("member_id", { ascending: true })
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true })
       .range(from, to);
-    return { rows: (data ?? []) as ReviewRow[], error: Boolean(error) };
+    assertEventRewardQuerySucceeded(error, "partner_reviews");
+    return { rows: (data ?? []) as ReviewRow[], error: false };
   });
   const counts = new Map<string, number>();
   for (const row of result.rows) {

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -24,6 +24,7 @@ export {
 export {
   deactivateAllPushSubscriptions,
   deactivatePushSubscription,
+  countActivePushSubscriptions,
   listPushSubscriptionDevices,
   upsertPushSubscription,
 } from "./push/subscriptions.ts";

--- a/src/lib/push/subscriptions.ts
+++ b/src/lib/push/subscriptions.ts
@@ -105,6 +105,10 @@ export async function deactivatePushSubscription(params: {
     throw wrapPushDbError(error, "Push 구독을 비활성화하지 못했습니다.");
   }
 
+  if ((await countActivePushSubscriptions(memberId)) === 0) {
+    return upsertMemberPushPreferences(memberId, { enabled: false });
+  }
+
   return getMemberPushPreferences(memberId);
 }
 
@@ -169,6 +173,21 @@ export async function listPushSubscriptionDevices(params: {
     updatedAt: row.updated_at ?? null,
     lastSuccessAt: row.last_success_at ?? null,
   }));
+}
+
+export async function countActivePushSubscriptions(memberId: string) {
+  const supabase = getSupabaseAdminClient();
+  const { count, error } = await supabase
+    .from("push_subscriptions")
+    .select("id", { count: "exact", head: true })
+    .eq("member_id", memberId)
+    .eq("is_active", true);
+
+  if (error) {
+    throw wrapPushDbError(error, "Push 기기 상태를 확인하지 못했습니다.");
+  }
+
+  return count ?? 0;
 }
 
 export async function deactivateAllPushSubscriptions(memberId: string) {

--- a/tests/event-reward-admin.test.mts
+++ b/tests/event-reward-admin.test.mts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type EventRewardsModule = typeof import("../src/lib/promotions/event-rewards.ts");
+
+const eventRewardsModulePromise = import(
+  new URL("../src/lib/promotions/event-rewards.ts", import.meta.url).href
+) as Promise<EventRewardsModule>;
+
+const campaign = {
+  slug: "signup-reward",
+  title: "싸트너십 추첨권 이벤트",
+  shortTitle: "추첨권 이벤트",
+  description: "테스트 이벤트",
+  periodLabel: "테스트 기간",
+  startsAt: "2026-04-20T00:00:00+09:00",
+  endsAt: "2026-05-12T23:59:59+09:00",
+  heroImageSrc: "/ads/reward-event.svg",
+  heroImageAlt: "이벤트",
+  conditions: [
+    {
+      key: "signup" as const,
+      title: "회원가입",
+      description: "가입",
+      tickets: 1,
+      ctaHref: "/auth/signup",
+      ctaLabel: "회원가입",
+    },
+    {
+      key: "mm" as const,
+      title: "MM",
+      description: "MM",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "알림",
+    },
+    {
+      key: "push" as const,
+      title: "Push",
+      description: "Push",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "푸시",
+    },
+    {
+      key: "marketing" as const,
+      title: "Marketing",
+      description: "Marketing",
+      tickets: 2,
+      ctaHref: "/notifications",
+      ctaLabel: "동의",
+    },
+    {
+      key: "review" as const,
+      title: "Review",
+      description: "Review",
+      tickets: 1,
+      ctaHref: "/",
+      ctaLabel: "리뷰",
+      repeatable: true,
+    },
+  ],
+  rules: [],
+};
+
+test("event reward admin overview aggregates member rows and condition counts", async () => {
+  const { buildEventRewardAdminOverview } = await eventRewardsModulePromise;
+
+  const overview = buildEventRewardAdminOverview(campaign, [
+    {
+      id: "member-1",
+      displayName: "김싸피",
+      mmUsername: "kim",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: true,
+        marketingEnabled: false,
+      },
+      reviewCount: 2,
+    },
+    {
+      id: "member-2",
+      displayName: "이싸피",
+      mmUsername: "lee",
+      year: 14,
+      campus: "구미",
+      createdAt: "2026-05-13T00:00:00+09:00",
+      preferences: {
+        enabled: false,
+        mmEnabled: false,
+        marketingEnabled: true,
+      },
+      reviewCount: 0,
+    },
+  ]);
+
+  assert.equal(overview.memberCount, 2);
+  assert.equal(overview.totalTickets, 7);
+  assert.equal(overview.conditionCounts.signup, 1);
+  assert.equal(overview.conditionCounts.mm, 1);
+  assert.equal(overview.conditionCounts.push, 1);
+  assert.equal(overview.conditionCounts.marketing, 1);
+  assert.equal(overview.reviewCount, 2);
+  assert.equal(overview.members[0]?.totalTickets, 5);
+  assert.equal(overview.members[1]?.totalTickets, 2);
+});
+
+test("event reward csv export uses the same row values as admin overview", async () => {
+  const { buildEventRewardAdminOverview, createEventRewardCsv } =
+    await eventRewardsModulePromise;
+
+  const overview = buildEventRewardAdminOverview(campaign, [
+    {
+      id: "member-1",
+      displayName: "김,싸피",
+      mmUsername: "kim",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: false,
+        marketingEnabled: true,
+      },
+      reviewCount: 1,
+    },
+  ]);
+  const csv = createEventRewardCsv(overview);
+
+  assert.ok(csv.startsWith("\uFEFF"));
+  assert.match(csv, /이름,MM ID,기수,캠퍼스,총 추첨권/);
+  assert.match(csv, /"김,싸피",kim,15,서울,5,완료,미완료,완료,완료,1/);
+});

--- a/tests/event-rewards.test.mts
+++ b/tests/event-rewards.test.mts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type EventRewardsModule = typeof import("../src/lib/promotions/event-rewards.ts");
+
+const eventRewardsModulePromise = import(
+  new URL("../src/lib/promotions/event-rewards.ts", import.meta.url).href
+) as Promise<EventRewardsModule>;
+
+const campaign = {
+  slug: "signup-reward",
+  title: "싸트너십 추첨권 이벤트",
+  shortTitle: "추첨권 이벤트",
+  description: "테스트 이벤트",
+  periodLabel: "테스트 기간",
+  startsAt: "2026-04-20T00:00:00+09:00",
+  endsAt: "2026-05-12T23:59:59+09:00",
+  heroImageSrc: "/ads/reward-event.svg",
+  heroImageAlt: "이벤트",
+  conditions: [
+    {
+      key: "signup" as const,
+      title: "회원가입",
+      description: "가입",
+      tickets: 1,
+      ctaHref: "/auth/signup",
+      ctaLabel: "회원가입",
+    },
+    {
+      key: "mm" as const,
+      title: "MM",
+      description: "MM",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "알림",
+    },
+    {
+      key: "push" as const,
+      title: "Push",
+      description: "Push",
+      tickets: 1,
+      ctaHref: "/notifications",
+      ctaLabel: "푸시",
+    },
+    {
+      key: "marketing" as const,
+      title: "Marketing",
+      description: "Marketing",
+      tickets: 2,
+      ctaHref: "/notifications",
+      ctaLabel: "동의",
+    },
+    {
+      key: "review" as const,
+      title: "Review",
+      description: "Review",
+      tickets: 1,
+      ctaHref: "/",
+      ctaLabel: "리뷰",
+      repeatable: true,
+    },
+  ],
+  rules: [],
+};
+
+test("event reward signup condition includes members created before the campaign", async () => {
+  const { calculateEventRewardConditions } = await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-04-01T12:00:00+09:00",
+    preferences: null,
+    reviewCount: 0,
+  });
+
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.status, "received");
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.earnedTickets, 1);
+});
+
+test("event reward signup condition excludes members created after the campaign", async () => {
+  const { calculateEventRewardConditions } = await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-05-13T00:00:00+09:00",
+    preferences: {
+      enabled: true,
+      mmEnabled: true,
+      marketingEnabled: true,
+    },
+    reviewCount: 3,
+  });
+
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.status, "missing");
+  assert.equal(conditions.find((condition) => condition.key === "signup")?.earnedTickets, 0);
+});
+
+test("event reward conditions sum signup, notification, marketing, and review tickets", async () => {
+  const { calculateEventRewardConditions, sumEventRewardTickets } =
+    await eventRewardsModulePromise;
+
+  const conditions = calculateEventRewardConditions(campaign, {
+    createdAt: "2026-05-01T12:00:00+09:00",
+    preferences: {
+      enabled: true,
+      mmEnabled: false,
+      marketingEnabled: true,
+    },
+    reviewCount: 2,
+  });
+
+  assert.equal(sumEventRewardTickets(conditions), 6);
+  assert.deepEqual(
+    conditions.map((condition) => [condition.key, condition.earnedTickets]),
+    [
+      ["signup", 1],
+      ["mm", 0],
+      ["push", 1],
+      ["marketing", 2],
+      ["review", 2],
+    ],
+  );
+});

--- a/tests/push/wave1-helpers.test.mts
+++ b/tests/push/wave1-helpers.test.mts
@@ -177,6 +177,7 @@ test("push settings status derives stable labels and tones", async () => {
       iosNeedsInstall: false,
       isReceivingOnThisDevice: false,
       accountEnabled: false,
+      hasAnyPushDevice: false,
     }),
     { label: "서버 설정 필요", tone: "warn" },
   );
@@ -188,7 +189,20 @@ test("push settings status derives stable labels and tones", async () => {
       iosNeedsInstall: false,
       isReceivingOnThisDevice: true,
       accountEnabled: true,
+      hasAnyPushDevice: true,
     }),
     { label: "알림 수신 중", tone: "success" },
+  );
+
+  assert.equal(
+    derivePushSettingsStatus({
+      configured: true,
+      supported: true,
+      iosNeedsInstall: false,
+      isReceivingOnThisDevice: false,
+      accountEnabled: true,
+      hasAnyPushDevice: false,
+    }),
+    null,
   );
 });


### PR DESCRIPTION
## Summary
- `signup-reward` 이벤트 지급 계산을 이벤트 종료 전 가입자 기준으로 보정하고 어드민 추첨권 현황/CSV 내보내기를 추가합니다.
- 푸시 수신 기기가 없을 때 토글 상태가 켜짐으로 보이지 않도록 보정합니다.
- 홈 광고 관리에서 활성 이벤트 페이지 선택을 지원하고, 21:9 배너 미리보기/실제 캐러셀 표시가 잘리지 않도록 정규화합니다.

## Related Issues
- Closes #15
- Closes #20
- Closes #21
- Closes #22
- Closes #24
- Closes #26

## Branch Flow
- base: `main`
- head: `dev`
- `dev`에서 검증된 변경사항을 Production 연결 브랜치인 `main`으로 승격합니다.

## Changes
- 가입 리워드 이벤트 조건 계산과 관리자 현황 표/CSV export 추가
- 이벤트 페이지에서 signup-reward 히어로 이미지 패널 제거 및 배너 유지
- 푸시 기기 없는 상태의 preference/toggle UX 보정
- 홈 광고 관리의 이벤트 페이지 선택 드롭다운 및 stale 이벤트 저장 복구 처리
- 홈 광고 21:9 이미지를 클라이언트에서 2100x900 WebP로 정규화하고 `object-contain`으로 표시

## Test Plan
- `npm run release` on `dev`
  - Lighthouse: skipped
  - Storybook static build: passed
  - Storybook interaction/smoke: 75 files / 197 tests passed
- Focused lint before release:
  - `npx eslint src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx src/components/promotions/PromotionCarousel.tsx`
- Note: first local release attempt hit macOS sandbox permission failure launching Playwright Chromium; rerun with approved execution completed successfully.

## Checklist
- [x] Diff reviewed before release
- [x] `dev` pushed
- [x] Production promotion PR targets `main`
- [x] Related issues documented