### PR TITLE
perf: UX 성능 병목 쿼리와 로그 응답 경로 최적화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.23",
+  "version": "1.9.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.23",
+      "version": "1.9.24",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.23",
+  "version": "1.9.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/api/events/product/route.ts
+++ b/src/app/api/events/product/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isProductEventName } from '@/lib/event-catalog';
 import {
   getRequestLogContext,
-  logProductEvent,
   resolveCurrentActor,
+  scheduleProductEventLog,
 } from '@/lib/activity-logs';
 import { normalizeProductEventLocation } from '@/lib/product-event-path';
 
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     const actor = await resolveCurrentActor();
     const context = getRequestLogContext(request);
 
-    await logProductEvent({
+    scheduleProductEventLog({
       eventName: body.eventName,
       actorType: actor.actorType,
       actorId: actor.actorId,
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
       ipAddress: context.ipAddress,
     });
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true }, { status: 202 });
   } catch {
     return NextResponse.json({ message: '이벤트를 기록하지 못했습니다.' }, { status: 400 });
   }

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import { getSignedUserSession } from "@/lib/user-auth";
 import { updateMemberNotificationPreferences } from "@/lib/notification-preferences";
 
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       },
     );
 
-    await logProductEvent({
+    scheduleProductEventLog({
       ...context,
       eventName: "push_preference_change",
       actorType: "member",

--- a/src/app/api/partners/[id]/reviews/[reviewId]/reaction/route.ts
+++ b/src/app/api/partners/[id]/reviews/[reviewId]/reaction/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import { partnerReviewRepository } from "@/lib/repositories";
 import { ensureVisibleReviewPartner, getReviewMemberSession } from "../../_shared";
 
@@ -56,7 +56,7 @@ export async function PATCH(
       reaction,
     });
     if (reaction) {
-      await logProductEvent({
+      scheduleProductEventLog({
         ...getRequestLogContext(request),
         actorType: "member",
         actorId: session.userId,

--- a/src/app/api/partners/[id]/reviews/[reviewId]/route.ts
+++ b/src/app/api/partners/[id]/reviews/[reviewId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import { partnerReviewRepository } from "@/lib/repositories";
 import { deleteReviewMediaUrls } from "@/lib/review-media-storage";
 import {
@@ -73,7 +73,7 @@ export async function PATCH(
     const removedUrls = ownedReview.images.filter((url) => !media.images.includes(url));
     await deleteReviewMediaUrls(removedUrls).catch(() => undefined);
     const summary = await partnerReviewRepository.getPartnerReviewSummary(id);
-    await logProductEvent({
+    scheduleProductEventLog({
       ...getRequestLogContext(request),
       actorType: "member",
       actorId: session.userId,
@@ -138,7 +138,7 @@ export async function DELETE(
       memberId: session.userId,
     });
     const summary = await partnerReviewRepository.getPartnerReviewSummary(id);
-    await logProductEvent({
+    scheduleProductEventLog({
       ...getRequestLogContext(request),
       actorType: "member",
       actorId: session.userId,

--- a/src/app/api/partners/[id]/reviews/route.ts
+++ b/src/app/api/partners/[id]/reviews/route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import { partnerReviewRepository } from "@/lib/repositories";
 import { deleteReviewMediaUrls } from "@/lib/review-media-storage";
 import {
@@ -93,7 +93,7 @@ export async function POST(
       images: media.images,
     });
     const summary = await partnerReviewRepository.getPartnerReviewSummary(id);
-    await logProductEvent({
+    scheduleProductEventLog({
       ...getRequestLogContext(request),
       actorType: "member",
       actorId: session.userId,

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import {
   isMockNotificationPreferenceMode,
   upsertMockPushDevice,
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
           userAgent,
         });
 
-    await logProductEvent({
+    scheduleProductEventLog({
       ...context,
       eventName: "push_subscribe",
       actorType: "member",

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getRequestLogContext, logProductEvent } from "@/lib/activity-logs";
+import { getRequestLogContext, scheduleProductEventLog } from "@/lib/activity-logs";
 import {
   deactivateAllMockPushDevices,
   deactivateMockPushDevice,
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
               subscriptionId: body?.subscriptionId ?? null,
             });
 
-    await logProductEvent({
+    scheduleProductEventLog({
       ...context,
       eventName:
         scope === "all" ? "push_unsubscribe_all" : "push_unsubscribe_device",

--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   getRequestLogContext,
-  logProductEvent,
+  scheduleProductEventLog,
   resolveCurrentActor,
 } from "@/lib/activity-logs";
 import { BUG_REPORT_EMAIL } from "@/lib/site";
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
     });
 
     const actor = await resolveCurrentActor();
-    await logProductEvent({
+    scheduleProductEventLog({
       ...context,
       eventName: "suggest_submit",
       actorType: actor.actorType,

--- a/src/lib/activity-logs.ts
+++ b/src/lib/activity-logs.ts
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers';
+import { after } from 'next/server';
 import { getAdminSession } from '@/lib/auth';
 import {
   type AdminAuditAction,
@@ -227,6 +228,12 @@ export async function logProductEvent(input: ProductLogInput) {
       }
     }
   }
+}
+
+export function scheduleProductEventLog(input: ProductLogInput) {
+  after(async () => {
+    await logProductEvent(input);
+  });
 }
 
 export async function logAdminAudit(input: AdminAuditInput) {

--- a/src/lib/repositories/supabase/partner-repository.supabase.ts
+++ b/src/lib/repositories/supabase/partner-repository.supabase.ts
@@ -1,4 +1,5 @@
 import type { Category, Partner } from "@/lib/types";
+import { cache } from "react";
 import {
   normalizePartnerAudience,
 } from "@/lib/partner-audience";
@@ -81,7 +82,10 @@ function extractCategoryKey(categories: PartnerRow["categories"]) {
   return undefined;
 }
 
-async function getPublicCacheVersionKey(scopes: PublicCacheScope[]) {
+const getPublicCacheVersionKeyByScopeKey = cache(async (scopeKey: string) => {
+  const scopes = scopeKey.split(",").filter((value): value is PublicCacheScope =>
+    value === "partners" || value === "categories",
+  );
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase
     .from("public_cache_versions")
@@ -106,6 +110,11 @@ async function getPublicCacheVersionKey(scopes: PublicCacheScope[]) {
       return `${scope}:${row?.version ?? "0"}:${row?.updated_at ?? "missing"}`;
     })
     .join("|");
+});
+
+async function getPublicCacheVersionKey(scopes: PublicCacheScope[]) {
+  const normalizedScopes = [...new Set(scopes)].sort();
+  return getPublicCacheVersionKeyByScopeKey(normalizedScopes.join(","));
 }
 
 const getCachedCategories = unstable_cache(

--- a/supabase/migrations/20260512115334_ux_db_query_performance.sql
+++ b/supabase/migrations/20260512115334_ux_db_query_performance.sql
@@ -1,0 +1,356 @@
+-- Reduce UX-facing DB latency for public event tracking and admin log dashboards.
+-- Rollback, if needed:
+--   drop index if exists public.event_logs_created_at_id_idx;
+--   drop index if exists public.admin_audit_logs_created_at_id_idx;
+--   drop index if exists public.auth_security_logs_created_at_id_idx;
+--   drop index if exists public.event_logs_name_created_at_idx;
+--   drop index if exists public.admin_audit_logs_action_created_at_idx;
+--   drop index if exists public.auth_security_logs_name_status_created_at_idx;
+--   drop index if exists public.event_logs_actor_type_created_at_idx;
+--   drop index if exists public.admin_audit_logs_actor_created_at_idx;
+--   drop index if exists public.auth_security_logs_actor_status_created_at_idx;
+--   drop index if exists public.event_logs_path_prefix_idx;
+--   drop index if exists public.admin_audit_logs_path_prefix_idx;
+--   drop index if exists public.auth_security_logs_path_prefix_idx;
+
+create index if not exists event_logs_created_at_id_idx
+  on public.event_logs(created_at desc, id desc);
+
+create index if not exists admin_audit_logs_created_at_id_idx
+  on public.admin_audit_logs(created_at desc, id desc);
+
+create index if not exists auth_security_logs_created_at_id_idx
+  on public.auth_security_logs(created_at desc, id desc);
+
+create index if not exists event_logs_name_created_at_idx
+  on public.event_logs(event_name, created_at desc);
+
+create index if not exists admin_audit_logs_action_created_at_idx
+  on public.admin_audit_logs(action, created_at desc);
+
+create index if not exists auth_security_logs_name_status_created_at_idx
+  on public.auth_security_logs(event_name, status, created_at desc);
+
+create index if not exists event_logs_actor_type_created_at_idx
+  on public.event_logs(actor_type, created_at desc);
+
+create index if not exists admin_audit_logs_actor_created_at_idx
+  on public.admin_audit_logs(actor_id, created_at desc);
+
+create index if not exists auth_security_logs_actor_status_created_at_idx
+  on public.auth_security_logs(actor_type, status, created_at desc);
+
+create index if not exists event_logs_path_prefix_idx
+  on public.event_logs(path text_pattern_ops)
+  where path is not null;
+
+create index if not exists admin_audit_logs_path_prefix_idx
+  on public.admin_audit_logs(path text_pattern_ops)
+  where path is not null;
+
+create index if not exists auth_security_logs_path_prefix_idx
+  on public.auth_security_logs(path text_pattern_ops)
+  where path is not null;
+
+create or replace function public.get_admin_dashboard_counts()
+returns table (
+  member_count bigint,
+  company_count bigint,
+  partner_count bigint,
+  category_count bigint,
+  account_count bigint,
+  review_count bigint,
+  active_push_subscription_count bigint,
+  product_log_count bigint,
+  audit_log_count bigint,
+  security_log_count bigint
+)
+language sql
+stable
+set search_path = public
+as $$
+  select
+    (select count(*)::bigint from public.members) as member_count,
+    (select count(*)::bigint from public.partner_companies) as company_count,
+    (select count(*)::bigint from public.partners) as partner_count,
+    (select count(*)::bigint from public.categories) as category_count,
+    (select count(*)::bigint from public.partner_accounts) as account_count,
+    (
+      select count(*)::bigint
+      from public.partner_reviews
+      where deleted_at is null
+    ) as review_count,
+    (
+      select count(*)::bigint
+      from public.push_subscriptions
+      where is_active = true
+    ) as active_push_subscription_count,
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.event_logs'::regclass), 0),
+      0
+    ) as product_log_count,
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.admin_audit_logs'::regclass), 0),
+      0
+    ) as audit_log_count,
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.auth_security_logs'::regclass), 0),
+      0
+    ) as security_log_count;
+$$;
+
+create or replace function public.get_admin_logs_summary(
+  input_start timestamp with time zone,
+  input_end timestamp with time zone,
+  input_bucket_ms bigint
+)
+returns jsonb
+language sql
+stable
+set search_path = public
+as $$
+  with params as (
+    select
+      input_start as start_at,
+      input_end as end_at,
+      greatest(coalesce(input_bucket_ms, 60000), 60000)::bigint as bucket_ms
+  ),
+  product_logs as materialized (
+    select
+      'product'::text as group_name,
+      event_logs.event_name::text as name,
+      null::text as status,
+      event_logs.actor_type::text as actor_type,
+      coalesce(
+        nullif('@' || members.mm_username, '@'),
+        nullif(members.display_name, ''),
+        nullif(event_logs.actor_id, ''),
+        case when event_logs.actor_type = 'guest' then '비로그인 사용자' end
+      ) as actor_label,
+      event_logs.ip_address::text as ip_address,
+      event_logs.path::text as path,
+      event_logs.created_at
+    from public.event_logs
+    left join public.members
+      on event_logs.actor_type = 'member'
+     and members.id::text = event_logs.actor_id
+    cross join params
+    where event_logs.created_at >= params.start_at
+      and event_logs.created_at <= params.end_at
+  ),
+  audit_logs as materialized (
+    select
+      'audit'::text as group_name,
+      admin_audit_logs.action::text as name,
+      null::text as status,
+      'admin'::text as actor_type,
+      coalesce(nullif(admin_audit_logs.actor_id, ''), 'admin') as actor_label,
+      admin_audit_logs.ip_address::text as ip_address,
+      admin_audit_logs.path::text as path,
+      admin_audit_logs.created_at
+    from public.admin_audit_logs
+    cross join params
+    where admin_audit_logs.created_at >= params.start_at
+      and admin_audit_logs.created_at <= params.end_at
+  ),
+  security_logs as materialized (
+    select
+      'security'::text as group_name,
+      auth_security_logs.event_name::text as name,
+      auth_security_logs.status::text as status,
+      auth_security_logs.actor_type::text as actor_type,
+      coalesce(
+        nullif('@' || members.mm_username, '@'),
+        nullif(members.display_name, ''),
+        nullif(auth_security_logs.identifier, ''),
+        nullif(auth_security_logs.actor_id, ''),
+        case when auth_security_logs.actor_type = 'guest' then '비로그인 사용자' end
+      ) as actor_label,
+      auth_security_logs.ip_address::text as ip_address,
+      auth_security_logs.path::text as path,
+      auth_security_logs.created_at
+    from public.auth_security_logs
+    left join public.members
+      on auth_security_logs.actor_type = 'member'
+     and members.id::text = auth_security_logs.actor_id
+    cross join params
+    where auth_security_logs.created_at >= params.start_at
+      and auth_security_logs.created_at <= params.end_at
+  ),
+  unified_logs as materialized (
+    select * from product_logs
+    union all
+    select * from audit_logs
+    union all
+    select * from security_logs
+  ),
+  bucket_series as (
+    select
+      generate_series(
+        0,
+        greatest(
+          ceil(extract(epoch from (params.end_at - params.start_at)) * 1000 / params.bucket_ms)::integer - 1,
+          0
+        )
+      ) as bucket_index
+    from params
+  ),
+  bucketed_logs as materialized (
+    select
+      floor(extract(epoch from (unified_logs.created_at - params.start_at)) * 1000 / params.bucket_ms)::integer as bucket_index,
+      unified_logs.group_name
+    from unified_logs
+    cross join params
+  ),
+  buckets as (
+    select
+      (params.start_at + ((bucket_series.bucket_index * params.bucket_ms)::double precision * interval '1 millisecond')) as bucket_start,
+      least(
+        params.end_at,
+        params.start_at + (((bucket_series.bucket_index + 1) * params.bucket_ms)::double precision * interval '1 millisecond')
+      ) as bucket_end,
+      count(*) filter (where bucketed_logs.group_name = 'product')::bigint as product_count,
+      count(*) filter (where bucketed_logs.group_name = 'audit')::bigint as audit_count,
+      count(*) filter (where bucketed_logs.group_name = 'security')::bigint as security_count,
+      count(bucketed_logs.group_name)::bigint as total_count
+    from bucket_series
+    cross join params
+    left join bucketed_logs
+      on bucketed_logs.bucket_index = bucket_series.bucket_index
+    group by bucket_series.bucket_index, params.start_at, params.end_at, params.bucket_ms
+    order by bucket_series.bucket_index
+  )
+  select jsonb_build_object(
+    'counts',
+    jsonb_build_object(
+      'product', (select count(*) from product_logs),
+      'audit', (select count(*) from audit_logs),
+      'security', (select count(*) from security_logs)
+    ),
+    'securityStatusCounts',
+    jsonb_build_object(
+      'success', (select count(*) from security_logs where status = 'success'),
+      'failure', (select count(*) from security_logs where status = 'failure'),
+      'blocked', (select count(*) from security_logs where status = 'blocked')
+    ),
+    'buckets',
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'start', bucket_start,
+            'end', bucket_end,
+            'product', product_count,
+            'audit', audit_count,
+            'security', security_count,
+            'total', total_count
+          )
+          order by bucket_start
+        )
+        from buckets
+      ),
+      '[]'::jsonb
+    ),
+    'availableNames',
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object('group', group_name, 'name', name)
+          order by group_name, name
+        )
+        from (
+          select distinct group_name, name
+          from unified_logs
+          where name is not null
+        ) names
+      ),
+      '[]'::jsonb
+    ),
+    'actorOptions',
+    coalesce(
+      (
+        select jsonb_agg(actor_type order by actor_type)
+        from (
+          select distinct actor_type
+          from unified_logs
+          where actor_type is not null
+        ) actors
+      ),
+      '[]'::jsonb
+    ),
+    'topProductEvents',
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('name', name, 'count', event_count) order by event_count desc, name)
+        from (
+          select name, count(*)::bigint as event_count
+          from product_logs
+          group by name
+          order by event_count desc, name
+          limit 5
+        ) ranked
+      ),
+      '[]'::jsonb
+    ),
+    'topAuditActions',
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('name', name, 'count', action_count) order by action_count desc, name)
+        from (
+          select name, count(*)::bigint as action_count
+          from audit_logs
+          group by name
+          order by action_count desc, name
+          limit 5
+        ) ranked
+      ),
+      '[]'::jsonb
+    ),
+    'topActors',
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('label', actor_label, 'count', actor_count) order by actor_count desc, actor_label)
+        from (
+          select actor_label, count(*)::bigint as actor_count
+          from unified_logs
+          where actor_label is not null
+            and actor_label <> '비로그인 사용자'
+          group by actor_label
+          order by actor_count desc, actor_label
+          limit 5
+        ) ranked
+      ),
+      '[]'::jsonb
+    ),
+    'topIps',
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('label', ip_address, 'count', ip_count) order by ip_count desc, ip_address)
+        from (
+          select ip_address, count(*)::bigint as ip_count
+          from unified_logs
+          where ip_address is not null
+          group by ip_address
+          order by ip_count desc, ip_address
+          limit 5
+        ) ranked
+      ),
+      '[]'::jsonb
+    ),
+    'topPaths',
+    coalesce(
+      (
+        select jsonb_agg(jsonb_build_object('label', path, 'count', path_count) order by path_count desc, path)
+        from (
+          select path, count(*)::bigint as path_count
+          from unified_logs
+          where path is not null
+          group by path
+          order by path_count desc, path
+          limit 5
+        ) ranked
+      ),
+      '[]'::jsonb
+    )
+  );
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -560,9 +560,18 @@ as $$
       from public.push_subscriptions
       where is_active = true
     ) as active_push_subscription_count,
-    (select count(*)::bigint from public.event_logs) as product_log_count,
-    (select count(*)::bigint from public.admin_audit_logs) as audit_log_count,
-    (select count(*)::bigint from public.auth_security_logs) as security_log_count;
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.event_logs'::regclass), 0),
+      0
+    ) as product_log_count,
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.admin_audit_logs'::regclass), 0),
+      0
+    ) as audit_log_count,
+    greatest(
+      coalesce((select reltuples::bigint from pg_class where oid = 'public.auth_security_logs'::regclass), 0),
+      0
+    ) as security_log_count;
 $$;
 
 create or replace function public.get_admin_logs_page(
@@ -2043,13 +2052,22 @@ create index if not exists members_year_campus_display_name_idx
 create index if not exists members_campus_display_name_idx
   on members(campus, display_name);
 create index if not exists event_logs_created_at_idx on event_logs(created_at desc);
+create index if not exists event_logs_created_at_id_idx
+  on event_logs(created_at desc, id desc);
 create index if not exists event_logs_event_name_idx on event_logs(event_name);
+create index if not exists event_logs_name_created_at_idx
+  on event_logs(event_name, created_at desc);
 create index if not exists event_logs_actor_id_idx on event_logs(actor_id);
+create index if not exists event_logs_actor_type_created_at_idx
+  on event_logs(actor_type, created_at desc);
 create index if not exists event_logs_target_idx on event_logs(target_type, target_id);
 create index if not exists event_logs_partner_metric_idx
   on event_logs(target_type, target_id, event_name, created_at)
   where target_id is not null;
 create index if not exists event_logs_path_idx on event_logs(path);
+create index if not exists event_logs_path_prefix_idx
+  on event_logs(path text_pattern_ops)
+  where path is not null;
 create index if not exists event_logs_session_id_idx on event_logs(session_id);
 create unique index if not exists partner_metric_rollups_total_unique_idx
   on partner_metric_rollups(partner_id, metric_name, metric_kind, bucket_timezone)
@@ -2089,14 +2107,32 @@ create unique index if not exists partner_metric_unique_visitors_weekday_unique_
 create index if not exists partner_metric_unique_visitors_partner_metric_idx
   on partner_metric_unique_visitors(partner_id, metric_name, granularity);
 create index if not exists admin_audit_logs_created_at_idx on admin_audit_logs(created_at desc);
+create index if not exists admin_audit_logs_created_at_id_idx
+  on admin_audit_logs(created_at desc, id desc);
 create index if not exists admin_audit_logs_action_idx on admin_audit_logs(action);
+create index if not exists admin_audit_logs_action_created_at_idx
+  on admin_audit_logs(action, created_at desc);
 create index if not exists admin_audit_logs_actor_id_idx on admin_audit_logs(actor_id);
+create index if not exists admin_audit_logs_actor_created_at_idx
+  on admin_audit_logs(actor_id, created_at desc);
 create index if not exists admin_audit_logs_target_idx on admin_audit_logs(target_type, target_id);
+create index if not exists admin_audit_logs_path_prefix_idx
+  on admin_audit_logs(path text_pattern_ops)
+  where path is not null;
 create index if not exists auth_security_logs_created_at_idx on auth_security_logs(created_at desc);
+create index if not exists auth_security_logs_created_at_id_idx
+  on auth_security_logs(created_at desc, id desc);
 create index if not exists auth_security_logs_event_name_idx on auth_security_logs(event_name);
 create index if not exists auth_security_logs_status_idx on auth_security_logs(status);
+create index if not exists auth_security_logs_name_status_created_at_idx
+  on auth_security_logs(event_name, status, created_at desc);
 create index if not exists auth_security_logs_actor_id_idx on auth_security_logs(actor_id);
+create index if not exists auth_security_logs_actor_status_created_at_idx
+  on auth_security_logs(actor_type, status, created_at desc);
 create index if not exists auth_security_logs_identifier_idx on auth_security_logs(identifier);
+create index if not exists auth_security_logs_path_prefix_idx
+  on auth_security_logs(path text_pattern_ops)
+  where path is not null;
 create index if not exists auth_security_logs_member_policy_consent_idx
   on auth_security_logs(actor_type, event_name, status, actor_id, created_at desc)
   where actor_id is not null;


### PR DESCRIPTION
## Summary
- 제품 이벤트 로그 기록을 응답 이후 작업으로 넘겨 사용자 응답이 event_logs insert 지연에 묶이지 않도록 개선했습니다.
- 공개 파트너 repository의 public_cache_versions 조회를 request 단위로 memoization했습니다.
- 관리자 로그/대시보드 RPC 성능 보강을 위한 인덱스와 집계 구조를 추가했습니다.

## Related Issue
Refs #30

## Branch Flow
- base: dev
- head: perf/ux-db-query-optimization
- dev Preview 검증 후 main 승격

## Changes
- scheduleProductEventLog를 추가하고 제품/제안/푸시/리뷰 API의 제품 이벤트 로그 기록을 after-response 작업으로 전환
- Supabase partner repository의 cache version lookup을 react cache로 request 단위 중복 제거
- 로그 테이블 created_at/id, event/action/status/actor/path prefix 조회 보조 인덱스 추가
- get_admin_dashboard_counts의 로그 총계는 pg_class.reltuples 기반 추정값으로 전환
- get_admin_logs_summary 반복 참조 CTE를 materialized로 고정

## Test Plan
- [x] npx eslint changed files
- [x] node scripts/validate-supabase-migrations.mjs
- [x] node --import ./tests/alias-register.mjs --test tests/partner-counts.test.mts tests/admin-log-loading-strategy.test.mts tests/log-insights-paging.test.mts tests/partner-portal.mock.test.mts tests/partner-review-reactions.test.mts tests/review-draft-validation.test.mts
- [x] npm run build

## Checklist
- [x] Issue linked with Refs #30
- [x] DB migration added with schema snapshot update
- [x] Product log failures do not block user response
- [x] Existing count/log behavior remains compatible