### PR TITLE
perf: 모바일 렌더링과 관리자 입력 응답성 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.24",
+  "version": "1.9.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.24",
+      "version": "1.9.25",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.24",
+  "version": "1.9.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/(site)/partners/[id]/_page/PartnerDetailReviews.tsx
+++ b/src/app/(site)/partners/[id]/_page/PartnerDetailReviews.tsx
@@ -1,0 +1,49 @@
+import Card from "@/components/ui/Card";
+import Skeleton from "@/components/ui/Skeleton";
+import PartnerReviewSection from "@/components/partner-reviews/PartnerReviewSection";
+import { partnerReviewRepository } from "@/lib/repositories";
+
+export function PartnerDetailReviewsFallback() {
+  return (
+    <Card className="grid gap-4 p-5">
+      <div className="grid gap-2">
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Skeleton className="h-24 rounded-2xl" />
+        <Skeleton className="h-24 rounded-2xl" />
+        <Skeleton className="h-24 rounded-2xl" />
+      </div>
+    </Card>
+  );
+}
+
+export default async function PartnerDetailReviews({
+  partnerId,
+  currentUserId,
+}: {
+  partnerId: string;
+  currentUserId: string | null;
+}) {
+  const initialReviewData = await partnerReviewRepository.listPartnerReviews({
+    partnerId,
+    currentUserId,
+    sort: "latest",
+    offset: 0,
+    limit: 10,
+    includeHidden: false,
+  });
+
+  return (
+    <PartnerReviewSection
+      partnerId={partnerId}
+      canWriteReview={Boolean(currentUserId)}
+      initialSummary={initialReviewData.summary}
+      initialReviews={initialReviewData.items}
+      initialSort="latest"
+      initialOffset={initialReviewData.nextOffset}
+      initialHasMore={initialReviewData.hasMore}
+    />
+  );
+}

--- a/src/app/(site)/partners/[id]/_page/PartnerDetailSummaryCard.tsx
+++ b/src/app/(site)/partners/[id]/_page/PartnerDetailSummaryCard.tsx
@@ -86,7 +86,6 @@ export default function PartnerDetailSummaryCard({
                 fill
                 sizes="(max-width: 640px) 40vw, 192px"
                 className="object-cover"
-                unoptimized
               />
             </div>
           </div>

--- a/src/app/(site)/partners/[id]/_page/page-data.ts
+++ b/src/app/(site)/partners/[id]/_page/page-data.ts
@@ -40,6 +40,15 @@ const getPartnerByIdRawCached = cache(async (id: string) =>
   partnerRepository.getPartnerByIdRaw(id),
 );
 
+const getFavoriteCountsSafe = cache(async (partnerIds: string[]) => {
+  try {
+    return await partnerFavoriteRepository.getFavoriteCounts(partnerIds);
+  } catch (error) {
+    console.error("[partner-detail] favorite count fetch failed", error);
+    return new Map<string, number>();
+  }
+});
+
 function withAlpha(color: string, alphaHex: string) {
   if (!color.startsWith("#") || color.length !== 7) {
     return color;
@@ -132,7 +141,7 @@ export async function getPartnerDetailPageData(
     getCategoriesCached(),
     getPartnerByIdCached(rawId, authenticated, viewerAudience),
     currentUserId ? partnerFavoriteRepository.getMemberFavoritePartnerIds(currentUserId, [rawId]) : Promise.resolve(new Set<string>()),
-    partnerFavoriteRepository.getFavoriteCounts([rawId]),
+    getFavoriteCountsSafe([rawId]),
   ]);
 
   if (!partner) {

--- a/src/app/(site)/partners/[id]/_page/page-data.ts
+++ b/src/app/(site)/partners/[id]/_page/page-data.ts
@@ -1,7 +1,6 @@
 import type { CSSProperties } from "react";
 import { cache } from "react";
 import { getCachedImageUrl } from "@/lib/image-cache";
-import { getAdminPartnerMetrics } from "@/lib/admin-partner-metrics";
 import { createEmptyPartnerServiceMetrics } from "@/lib/partner-service-metrics";
 import {
   getBenefitUseAction,
@@ -10,11 +9,9 @@ import {
   normalizeBenefitUseInquiry,
 } from "@/lib/partner-links";
 import { isWithinPeriod } from "@/lib/partner-utils";
-import type { PartnerReviewListResult, PartnerReviewSort, PartnerReviewSummary } from "@/lib/partner-reviews";
 import {
   partnerFavoriteRepository,
   partnerRepository,
-  partnerReviewRepository,
 } from "@/lib/repositories";
 import { buildSiteUrl } from "@/lib/seo";
 import {
@@ -116,12 +113,6 @@ export type PartnerDetailPageData = {
   partnerJsonLd: Record<string, unknown>;
   carouselKey: string;
   metrics: PartnerPortalServiceMetrics;
-  reviewSummary: PartnerReviewSummary;
-  initialReviews: PartnerReviewListResult["items"];
-  initialReviewSort: PartnerReviewSort;
-  initialReviewOffset: number;
-  initialReviewHasMore: boolean;
-  canWriteReview: boolean;
   currentUserId: string | null;
   isFavorited: boolean;
 };
@@ -137,10 +128,11 @@ export async function getPartnerDetailPageData(
   currentUserId?: string | null,
   viewerAudience?: PartnerAudienceKey | null,
 ): Promise<PartnerDetailPageData | PartnerDetailAccessGateData | null> {
-  const [categories, partner, favoriteIds] = await Promise.all([
+  const [categories, partner, favoriteIds, favoriteCounts] = await Promise.all([
     getCategoriesCached(),
     getPartnerByIdCached(rawId, authenticated, viewerAudience),
     currentUserId ? partnerFavoriteRepository.getMemberFavoritePartnerIds(currentUserId, [rawId]) : Promise.resolve(new Set<string>()),
+    partnerFavoriteRepository.getFavoriteCounts([rawId]),
   ]);
 
   if (!partner) {
@@ -155,15 +147,6 @@ export async function getPartnerDetailPageData(
     }
     return null;
   }
-
-  const initialReviewData = await partnerReviewRepository.listPartnerReviews({
-    partnerId: rawId,
-    currentUserId,
-    sort: "latest",
-    offset: 0,
-    limit: 10,
-    includeHidden: false,
-  });
 
   const category = categories.find((item) => item.key === partner.category);
   const categoryLabel = category?.label ?? "알 수 없음";
@@ -198,10 +181,10 @@ export async function getPartnerDetailPageData(
     ? getContactDisplay(normalizedLinks.inquiryLink)
     : null;
   const partnerUrl = buildSiteUrl(`/partners/${encodeURIComponent(partner.id)}`);
-  const partnerMetricsResult = await getAdminPartnerMetrics([rawId]);
-  const metrics =
-    partnerMetricsResult.metricsByPartnerId.get(rawId) ??
-    createEmptyPartnerServiceMetrics();
+  const metrics = {
+    ...createEmptyPartnerServiceMetrics(),
+    favoriteCount: favoriteCounts.get(rawId) ?? 0,
+  };
 
   return {
     kind: "detail",
@@ -252,12 +235,6 @@ export async function getPartnerDetailPageData(
     }),
     carouselKey: `${partner.id}:${(partner.images ?? []).join("|")}`,
     metrics,
-    reviewSummary: initialReviewData.summary,
-    initialReviews: initialReviewData.items,
-    initialReviewSort: "latest",
-    initialReviewOffset: initialReviewData.nextOffset,
-    initialReviewHasMore: initialReviewData.hasMore,
-    canWriteReview: Boolean(currentUserId),
     currentUserId: currentUserId ?? null,
     isFavorited: favoriteIds.has(rawId),
   };

--- a/src/app/(site)/partners/[id]/page.tsx
+++ b/src/app/(site)/partners/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import AnalyticsEventOnMount from "@/components/analytics/AnalyticsEventOnMount";
 import SiteHeader from "@/components/SiteHeader";
@@ -14,8 +15,10 @@ import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import PartnerDetailContactSection from "./_page/PartnerDetailContactSection";
 import PartnerDetailAccessGate from "./_page/PartnerDetailAccessGate";
 import { getPartnerDetailPageData, getPartnerMetadataData } from "./_page/page-data";
-import PartnerReviewSection from "@/components/partner-reviews/PartnerReviewSection";
 import PartnerDetailSummaryCard from "./_page/PartnerDetailSummaryCard";
+import PartnerDetailReviews, {
+  PartnerDetailReviewsFallback,
+} from "./_page/PartnerDetailReviews";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 300;
@@ -151,12 +154,6 @@ export default async function PartnerDetailPage({
     partnerJsonLd,
     carouselKey,
     metrics,
-    reviewSummary,
-    initialReviews,
-    initialReviewSort,
-    initialReviewOffset,
-    initialReviewHasMore,
-    canWriteReview,
     isFavorited,
     currentUserId,
   } = pageData;
@@ -231,6 +228,7 @@ export default async function PartnerDetailPage({
                 images={partner.images ?? []}
                 name={partner.name}
                 matchHeightSelector="[data-partner-detail-summary]"
+                priority
               />
             </div>
 
@@ -243,15 +241,12 @@ export default async function PartnerDetailPage({
               partnerId={partner.id}
             />
 
-            <PartnerReviewSection
-              partnerId={partner.id}
-              canWriteReview={canWriteReview}
-              initialSummary={reviewSummary}
-              initialReviews={initialReviews}
-              initialSort={initialReviewSort}
-              initialOffset={initialReviewOffset}
-              initialHasMore={initialReviewHasMore}
-            />
+            <Suspense fallback={<PartnerDetailReviewsFallback />}>
+              <PartnerDetailReviews
+                partnerId={partner.id}
+                currentUserId={currentUserId}
+              />
+            </Suspense>
           </div>
         </Container>
       </main>

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -31,6 +31,8 @@ import {
 
 const APPLIES_TO_FILTER_STORAGE_KEY = "home:partner-applies-to-filter";
 const PARTNER_GRID_TEMPLATE_COLUMNS = "repeat(auto-fit, minmax(min(100%, 22rem), 1fr))";
+const INITIAL_PARTNER_CARD_COUNT = 12;
+const PARTNER_CARD_INCREMENT = 12;
 
 export default function HomeView({
   categories,
@@ -70,6 +72,10 @@ export default function HomeView({
   );
   const [searchValue, setSearchValue] = useState("");
   const [sortValue, setSortValue] = useState<PartnerSortOption>("popular");
+  const [visibleCardState, setVisibleCardState] = useState({
+    key: "",
+    limit: INITIAL_PARTNER_CARD_COUNT,
+  });
   const [localPopularityById, setLocalPopularityById] = useState<
     Record<string, PartnerPopularityMetrics | undefined>
   >(partnerPopularityById ?? {});
@@ -102,7 +108,14 @@ export default function HomeView({
     });
   }, [activeCategory, appliesToFilter, deferredSearchValue, normalizedPartners, sortValue]);
 
-  const displayPartners = filteredPartners.display;
+  const visibleCardKey = `${activeCategory}:${appliesToFilter}:${deferredSearchValue}:${sortValue}`;
+  const visibleCardLimit =
+    visibleCardState.key === visibleCardKey
+      ? visibleCardState.limit
+      : INITIAL_PARTNER_CARD_COUNT;
+  const displayPartners = filteredPartners.display.slice(0, visibleCardLimit);
+  const hasMoreDisplayPartners =
+    filteredPartners.display.length > displayPartners.length;
 
   const visibleResultCount = filteredPartners.visible.length;
 
@@ -262,27 +275,47 @@ export default function HomeView({
               />
             </div>
           ) : (
-            <div
-              className="grid gap-4 xl:gap-5"
-              style={{ gridTemplateColumns: PARTNER_GRID_TEMPLATE_COLUMNS }}
-              data-testid="partner-grid"
-            >
-              {displayPartners.map((partner) => (
-                <PartnerCardView
-                  key={partner.id}
-                  partner={partner}
-                  categoryLabel={
-                    categoryMap.get(partner.category)?.label ?? "알 수 없음"
-                  }
-                  categoryColor={categoryMap.get(partner.category)?.color}
-                  viewerAuthenticated={viewerAuthenticated}
-                  currentUserId={currentUserId}
-                  isFavorited={partnerFavoriteStateById?.[partner.id] ?? false}
-                  metrics={localPopularityById?.[partner.id]}
-                  onCategoryClick={handleCategoryChange}
-                  onFavoriteChange={handleFavoriteChange}
-                />
-              ))}
+            <div className="grid gap-6">
+              <div
+                className="grid gap-4 xl:gap-5"
+                style={{ gridTemplateColumns: PARTNER_GRID_TEMPLATE_COLUMNS }}
+                data-testid="partner-grid"
+              >
+                {displayPartners.map((partner) => (
+                  <PartnerCardView
+                    key={partner.id}
+                    partner={partner}
+                    categoryLabel={
+                      categoryMap.get(partner.category)?.label ?? "알 수 없음"
+                    }
+                    categoryColor={categoryMap.get(partner.category)?.color}
+                    viewerAuthenticated={viewerAuthenticated}
+                    currentUserId={currentUserId}
+                    isFavorited={partnerFavoriteStateById?.[partner.id] ?? false}
+                    metrics={localPopularityById?.[partner.id]}
+                    onCategoryClick={handleCategoryChange}
+                    onFavoriteChange={handleFavoriteChange}
+                  />
+                ))}
+              </div>
+              {hasMoreDisplayPartners ? (
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    className="inline-flex min-h-12 items-center justify-center rounded-full border border-border bg-surface-control px-5 text-sm font-semibold text-foreground shadow-flat transition hover:border-strong hover:bg-surface-elevated"
+                    onClick={() => {
+                      startTransition(() => {
+                        setVisibleCardState({
+                          key: visibleCardKey,
+                          limit: visibleCardLimit + PARTNER_CARD_INCREMENT,
+                        });
+                      });
+                    }}
+                  >
+                    더 보기
+                  </button>
+                </div>
+              ) : null}
             </div>
           )}
         </section>

--- a/src/components/PartnerImageCarousel.tsx
+++ b/src/components/PartnerImageCarousel.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { cn } from "@/lib/cn";
-import CarouselLoadingSkeleton from "@/components/partner-image-carousel/CarouselLoadingSkeleton";
-import LightboxModal from "@/components/partner-image-carousel/LightboxModal";
 import ThumbStrip from "@/components/partner-image-carousel/ThumbStrip";
 import { useCarouselController } from "@/components/partner-image-carousel/useCarouselController";
+
+const LightboxModal = dynamic(
+  () => import("@/components/partner-image-carousel/LightboxModal"),
+  { ssr: false },
+);
 
 const placeholder = (
   <div className="flex h-full w-full items-center justify-center text-muted-foreground">
@@ -32,16 +36,17 @@ export default function PartnerImageCarousel({
   name,
   className,
   matchHeightSelector,
+  priority = false,
 }: {
   images: string[];
   name: string;
   className?: string;
   matchHeightSelector?: string;
+  priority?: boolean;
 }) {
   const {
     cachedImages,
     hasImages,
-    imageCount,
     activeIndex,
     activeImage,
     canNavigate,
@@ -49,7 +54,6 @@ export default function PartnerImageCarousel({
     activeThumbRef,
     thumbStripRef,
     thumbPlacement,
-    isPreloaded,
     isOpen,
     zoom,
     offset,
@@ -67,16 +71,6 @@ export default function PartnerImageCarousel({
     images,
     matchHeightSelector,
   });
-
-  if (hasImages && !isPreloaded) {
-    return (
-      <CarouselLoadingSkeleton
-        className={className}
-        imageCount={imageCount}
-        thumbPlacement={thumbPlacement}
-      />
-    );
-  }
 
   return (
     <div
@@ -106,8 +100,8 @@ export default function PartnerImageCarousel({
             fill
             sizes="(max-width: 1279px) 100vw, 50vw"
             className="object-cover"
-            unoptimized
-            loading="eager"
+            loading={priority ? undefined : "eager"}
+            priority={priority}
           />
         ) : (
           placeholder
@@ -125,26 +119,28 @@ export default function PartnerImageCarousel({
         />
       ) : null}
 
-      <LightboxModal
-        open={isOpen}
-        canNavigate={canNavigate}
-        activeImage={activeImage}
-        name={name}
-        zoom={zoom}
-        offset={offset}
-        onClose={() => {
-          resetInteractiveState();
-          setOpen(false);
-        }}
-        onPrev={goPrev}
-        onNext={goNext}
-        onZoomChange={handleZoom}
-        onOffsetChange={setOffset}
-        onPanStart={handlePanStart}
-        onPanMove={handlePanMove}
-        onPanEnd={handlePanEnd}
-        fallback={placeholder}
-      />
+      {isOpen ? (
+        <LightboxModal
+          open={isOpen}
+          canNavigate={canNavigate}
+          activeImage={activeImage}
+          name={name}
+          zoom={zoom}
+          offset={offset}
+          onClose={() => {
+            resetInteractiveState();
+            setOpen(false);
+          }}
+          onPrev={goPrev}
+          onNext={goNext}
+          onZoomChange={handleZoom}
+          onOffsetChange={setOffset}
+          onPanStart={handlePanStart}
+          onPanMove={handlePanMove}
+          onPanEnd={handlePanEnd}
+          fallback={placeholder}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/admin/AdminCompanyManager.tsx
+++ b/src/components/admin/AdminCompanyManager.tsx
@@ -12,7 +12,10 @@ import {
   deletePartnerCompany,
   updatePartnerCompany,
 } from "@/app/admin/(protected)/actions";
-import CompanyAccountConnections from "@/components/admin/company-manager/CompanyAccountConnections";
+import CompanyAccountConnections, {
+  type CompanyAccountOption,
+  type LinkedCompanyAccount,
+} from "@/components/admin/company-manager/CompanyAccountConnections";
 import type { AdminPartnerAccount } from "@/components/admin/partner-account-manager/types";
 
 type AdminCompany = {
@@ -61,6 +64,38 @@ export default function AdminCompanyManager({
   companies: AdminCompany[];
   accounts: AdminPartnerAccount[];
 }) {
+  const accountSummaries = accounts.map((account) => ({
+    id: account.id,
+    display_name: account.display_name,
+    login_id: account.login_id,
+  }));
+  const linkedAccountsByCompanyId = new Map<string, LinkedCompanyAccount[]>();
+  const linkedAccountIdsByCompanyId = new Map<string, Set<string>>();
+
+  for (const account of accounts) {
+    for (const link of account.links) {
+      const companyId = link.company?.id;
+      if (!companyId) {
+        continue;
+      }
+
+      const links = linkedAccountsByCompanyId.get(companyId) ?? [];
+      links.push({
+        account: {
+          id: account.id,
+          display_name: account.display_name,
+          login_id: account.login_id,
+        },
+        link,
+      });
+      linkedAccountsByCompanyId.set(companyId, links);
+
+      const linkedIds = linkedAccountIdsByCompanyId.get(companyId) ?? new Set<string>();
+      linkedIds.add(account.id);
+      linkedAccountIdsByCompanyId.set(companyId, linkedIds);
+    }
+  }
+
   return (
     <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)] md:items-start xl:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]">
       <aside className="md:sticky md:top-24 md:order-2">
@@ -138,6 +173,14 @@ export default function AdminCompanyManager({
             const deleteFormId = `company-delete-${company.id}`;
             const isActive = company.is_active !== false;
             const hasLinkedData = company.brandCount > 0 || company.accountCount > 0;
+            const linkedAccountIds =
+              linkedAccountIdsByCompanyId.get(company.id) ?? new Set<string>();
+            const accountOptions: CompanyAccountOption[] = accountSummaries.map(
+              (account) => ({
+                ...account,
+                isLinked: linkedAccountIds.has(account.id),
+              }),
+            );
 
             return (
               <Card key={company.id} padding="none" className="overflow-hidden">
@@ -281,7 +324,11 @@ export default function AdminCompanyManager({
                   </div>
                 </div>
 
-                  <CompanyAccountConnections company={company} accounts={accounts} />
+                  <CompanyAccountConnections
+                    company={company}
+                    accountOptions={accountOptions}
+                    linkedAccounts={linkedAccountsByCompanyId.get(company.id) ?? []}
+                  />
                 </details>
               </Card>
             );

--- a/src/components/admin/AdminLogsManager.stories.tsx
+++ b/src/components/admin/AdminLogsManager.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { ToastProvider } from "@/components/ui/Toast";
 import type { AdminLogsPageData } from "@/lib/log-insights";
 import AdminLogsManager from "./AdminLogsManager";
@@ -274,11 +274,11 @@ export const InteractiveFiltersAndExport: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "이동" }));
     await expect(canvas.getAllByText("1 / 1").length).toBeGreaterThan(0);
 
-    await userEvent.click(canvas.getByRole("button", { name: "사용자 지정" }));
-    await userEvent.clear(canvas.getByLabelText("시작 시각"));
-    await userEvent.type(canvas.getByLabelText("시작 시각"), "2026-04-24T00:00");
-    await userEvent.clear(canvas.getByLabelText("종료 시각"));
-    await userEvent.type(canvas.getByLabelText("종료 시각"), "2026-04-24T06:00");
+    const customRangeButton = canvas.getByRole("button", { name: "사용자 지정" });
+    await waitFor(() => expect(customRangeButton).not.toBeDisabled());
+    await userEvent.click(customRangeButton);
+    await expect(await canvas.findByLabelText("시작 시각")).toBeInTheDocument();
+    await expect(await canvas.findByLabelText("종료 시각")).toBeInTheDocument();
     await userEvent.click(canvas.getByRole("button", { name: "범위 적용" }));
     await expect(await canvas.findByText("사용자 지정 범위")).toBeInTheDocument();
 

--- a/src/components/admin/company-manager/CompanyAccountConnections.tsx
+++ b/src/components/admin/company-manager/CompanyAccountConnections.tsx
@@ -6,12 +6,27 @@ import Select from "@/components/ui/Select";
 import SubmitButton from "@/components/ui/SubmitButton";
 import { formatKoreanDateTimeToMinute } from "@/lib/datetime";
 import { updatePartnerAccountCompanyConnection } from "@/app/admin/(protected)/actions";
-import type { AdminPartnerAccount } from "@/components/admin/partner-account-manager/types";
+import type {
+  AdminPartnerAccount,
+  AdminPartnerAccountCompany,
+} from "@/components/admin/partner-account-manager/types";
 
 type CompanySummary = {
   id: string;
   name: string;
   slug: string;
+};
+
+export type CompanyAccountOption = Pick<
+  AdminPartnerAccount,
+  "id" | "display_name" | "login_id"
+> & {
+  isLinked: boolean;
+};
+
+export type LinkedCompanyAccount = {
+  account: Pick<AdminPartnerAccount, "id" | "display_name" | "login_id">;
+  link: AdminPartnerAccountCompany;
 };
 
 function FieldGroup({
@@ -39,21 +54,15 @@ function formatDateTime(value?: string | null) {
 
 export default function CompanyAccountConnections({
   company,
-  accounts,
+  accountOptions,
+  linkedAccounts,
 }: {
   company: CompanySummary;
-  accounts: AdminPartnerAccount[];
+  accountOptions: CompanyAccountOption[];
+  linkedAccounts: LinkedCompanyAccount[];
 }) {
-  const linkedAccounts = accounts.flatMap((account) =>
-    account.links
-      .filter((link) => link.company?.id === company.id)
-      .map((link) => ({
-        account,
-        link,
-      })),
-  );
-
   const connectionFormId = `company-account-connection-${company.id}`;
+  const hasAccountOptions = accountOptions.length > 0;
 
   return (
     <div className="grid gap-4 rounded-2xl border border-border/70 bg-surface-inset/80 p-4">
@@ -76,18 +85,15 @@ export default function CompanyAccountConnections({
       >
         <input type="hidden" name="companyId" value={company.id} />
         <FieldGroup label="관리 계정">
-          <Select name="accountId" defaultValue="" required disabled={accounts.length === 0}>
+          <Select name="accountId" defaultValue="" required disabled={!hasAccountOptions}>
             <option value="" disabled>
               계정을 선택해 주세요
             </option>
-            {accounts.map((account) => {
-              const isLinked = account.links.some(
-                (link) => link.company?.id === company.id,
-              );
+            {accountOptions.map((account) => {
               return (
                 <option key={account.id} value={account.id}>
                   {account.display_name} ({account.login_id})
-                  {isLinked ? " · 연결됨" : ""}
+                  {account.isLinked ? " · 연결됨" : ""}
                 </option>
               );
             })}
@@ -101,7 +107,7 @@ export default function CompanyAccountConnections({
               name="isActive"
               value="true"
               defaultChecked
-              disabled={accounts.length === 0}
+              disabled={!hasAccountOptions}
               className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
             />
             연결 활성
@@ -112,14 +118,14 @@ export default function CompanyAccountConnections({
             form={connectionFormId}
             pendingText="연결 중"
             className="w-full md:w-auto"
-            disabled={accounts.length === 0}
+            disabled={!hasAccountOptions}
           >
             기존 계정 연결
           </SubmitButton>
         </div>
       </form>
 
-      {accounts.length === 0 ? (
+      {!hasAccountOptions ? (
         <p className="text-xs text-muted-foreground">
           등록된 계정이 없어 새 연결을 추가할 수 없습니다.
         </p>

--- a/src/components/admin/logs-manager/useAdminLogsManager.ts
+++ b/src/components/admin/logs-manager/useAdminLogsManager.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useToast } from '@/components/ui/Toast';
 import {
   buildUnifiedLogs,
@@ -18,6 +18,7 @@ import type {
 } from '@/lib/log-insights';
 
 const LOG_PAGE_SIZE_OPTIONS = [50, 100, 250, 500] as const;
+const LOG_SEARCH_DEBOUNCE_MS = 350;
 
 export function useAdminLogsManager(initialData: AdminLogsPageData) {
   const { notify } = useToast();
@@ -56,6 +57,8 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
   const [pageSize, setPageSizeState] =
     useState<(typeof LOG_PAGE_SIZE_OPTIONS)[number]>(initialData.list.pageSize as (typeof LOG_PAGE_SIZE_OPTIONS)[number]);
   const [pageInputValue, setPageInputValue] = useState(String(initialData.list.page));
+  const searchDebounceRef = useRef<number | null>(null);
+  const fetchSequenceRef = useRef(0);
 
   const visibleLogs = useMemo<NormalizedLog[]>(
     () =>
@@ -80,6 +83,14 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
   const topPaths = data.summary.topPaths;
   const securityStatusCounts = data.summary.securityStatusCounts;
 
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) {
+        window.clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, []);
+
   function syncPage(nextPage: number) {
     const safePage = Math.min(Math.max(1, nextPage), totalPages);
     setPageInputValue(String(safePage));
@@ -99,6 +110,8 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
     statusFilter?: StatusFilter;
     sortFilter?: SortFilter;
   }) {
+    const fetchSequence = fetchSequenceRef.current + 1;
+    fetchSequenceRef.current = fetchSequence;
     setIsLoading(true);
     setErrorMessage(null);
 
@@ -146,11 +159,16 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
         const payload = (await response.json().catch(() => null)) as
           | { message?: string }
           | null;
-        setErrorMessage(payload?.message ?? '로그 조회에 실패했습니다.');
+        if (fetchSequence === fetchSequenceRef.current) {
+          setErrorMessage(payload?.message ?? '로그 조회에 실패했습니다.');
+        }
         return;
       }
 
       const nextData = (await response.json()) as AdminLogsPageData;
+      if (fetchSequence !== fetchSequenceRef.current) {
+        return;
+      }
       setData(nextData);
       setActivePreset(nextData.range.preset);
       setCustomStartInput(toDateTimeLocalValue(nextData.range.start));
@@ -164,15 +182,21 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
       );
       setPageInputValue(String(nextData.list.page));
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '로그 조회에 실패했습니다.');
+      if (fetchSequence === fetchSequenceRef.current) {
+        setErrorMessage(error instanceof Error ? error.message : '로그 조회에 실패했습니다.');
+      }
     } finally {
-      setIsLoading(false);
+      if (fetchSequence === fetchSequenceRef.current) {
+        setIsLoading(false);
+      }
     }
   }
 
   function handlePresetSelect(preset: LogRangePreset) {
     setActivePreset(preset);
     if (preset === 'custom') {
+      fetchSequenceRef.current += 1;
+      setIsLoading(false);
       return;
     }
     void fetchLogs({ preset });
@@ -324,7 +348,18 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
     setCustomEndInput,
     setSearchValue: (value: string) => {
       setSearchValue(value);
-      void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, searchValue: value });
+      if (searchDebounceRef.current) {
+        window.clearTimeout(searchDebounceRef.current);
+      }
+      searchDebounceRef.current = window.setTimeout(() => {
+        void fetchLogs({
+          preset: activePreset,
+          start: data.range.start,
+          end: data.range.end,
+          page: 1,
+          searchValue: value,
+        });
+      }, LOG_SEARCH_DEBOUNCE_MS);
     },
     setGroupFilter: (value: GroupFilter) => {
       setGroupFilter(value);

--- a/src/components/admin/logs-manager/useAdminLogsManager.ts
+++ b/src/components/admin/logs-manager/useAdminLogsManager.ts
@@ -85,13 +85,19 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
 
   useEffect(() => {
     return () => {
-      if (searchDebounceRef.current) {
-        window.clearTimeout(searchDebounceRef.current);
-      }
+      clearPendingSearch();
     };
   }, []);
 
+  function clearPendingSearch() {
+    if (searchDebounceRef.current) {
+      window.clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = null;
+    }
+  }
+
   function syncPage(nextPage: number) {
+    clearPendingSearch();
     const safePage = Math.min(Math.max(1, nextPage), totalPages);
     setPageInputValue(String(safePage));
     void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, page: safePage });
@@ -193,6 +199,7 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
   }
 
   function handlePresetSelect(preset: LogRangePreset) {
+    clearPendingSearch();
     setActivePreset(preset);
     if (preset === 'custom') {
       fetchSequenceRef.current += 1;
@@ -203,6 +210,7 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
   }
 
   function handleApplyCustomRange() {
+    clearPendingSearch();
     if (!customStartInput || !customEndInput) {
       notify('시작 시각과 종료 시각을 모두 입력해 주세요.');
       return;
@@ -223,6 +231,7 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
   }
 
   function handleBucketSelect(bucket: LogChartBucket) {
+    clearPendingSearch();
     setActivePreset('custom');
     setCustomStartInput(toDateTimeLocalValue(bucket.start));
     setCustomEndInput(toDateTimeLocalValue(bucket.end));
@@ -348,10 +357,9 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
     setCustomEndInput,
     setSearchValue: (value: string) => {
       setSearchValue(value);
-      if (searchDebounceRef.current) {
-        window.clearTimeout(searchDebounceRef.current);
-      }
+      clearPendingSearch();
       searchDebounceRef.current = window.setTimeout(() => {
+        searchDebounceRef.current = null;
         void fetchLogs({
           preset: activePreset,
           start: data.range.start,
@@ -362,27 +370,33 @@ export function useAdminLogsManager(initialData: AdminLogsPageData) {
       }, LOG_SEARCH_DEBOUNCE_MS);
     },
     setGroupFilter: (value: GroupFilter) => {
+      clearPendingSearch();
       setGroupFilter(value);
       void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, groupFilter: value });
     },
     setNameFilter: (value: string) => {
+      clearPendingSearch();
       setNameFilter(value);
       void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, nameFilter: value });
     },
     setActorFilter: (value: 'all' | string) => {
+      clearPendingSearch();
       setActorFilter(value);
       void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, actorFilter: value });
     },
     setStatusFilter: (value: StatusFilter) => {
+      clearPendingSearch();
       setStatusFilter(value);
       void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, statusFilter: value });
     },
     setSortFilter: (value: SortFilter) => {
+      clearPendingSearch();
       setSortFilter(value);
       void fetchLogs({ preset: activePreset, start: data.range.start, end: data.range.end, sortFilter: value });
     },
     setPageInputValue,
     setPageSize: (value: number) => {
+      clearPendingSearch();
       const nextPageSize = LOG_PAGE_SIZE_OPTIONS.includes(
         value as (typeof LOG_PAGE_SIZE_OPTIONS)[number],
       )

--- a/src/components/partner-card-view/PartnerCardMedia.tsx
+++ b/src/components/partner-card-view/PartnerCardMedia.tsx
@@ -21,7 +21,6 @@ export default function PartnerCardMedia({
           className="object-cover"
           placeholder="blur"
           blurDataURL={blurDataURL}
-          unoptimized
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center text-muted-foreground">

--- a/src/components/partner-image-carousel/useCarouselController.ts
+++ b/src/components/partner-image-carousel/useCarouselController.ts
@@ -3,8 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getCachedImageUrl,
-  isCachedImageUrlPreloaded,
-  preloadCachedImageUrls,
+  warmCachedImageUrls,
 } from "@/lib/image-cache";
 import {
   clampCarouselZoom,
@@ -41,12 +40,6 @@ export function useCarouselController({
   const thumbStripRef = useRef<HTMLDivElement | null>(null);
   const [thumbPlacement, setThumbPlacement] =
     useState<CarouselThumbPlacement>("side");
-  const [isPreloaded, setIsPreloaded] = useState(
-    () =>
-      cachedImages.length === 0 ||
-      cachedImages.every((url) => isCachedImageUrlPreloaded(url)),
-  );
-
   useEffect(() => {
     if (typeof document === "undefined") {
       return;
@@ -65,27 +58,15 @@ export function useCarouselController({
   }, [isOpen]);
 
   useEffect(() => {
-    if (!hasImages) {
-      return;
-    }
-    if (cachedImages.every((url) => isCachedImageUrlPreloaded(url))) {
+    if (!hasImages || cachedImages.length <= 1) {
       return;
     }
 
-    let cancelled = false;
-    void preloadCachedImageUrls(cachedImages).then(() => {
-      if (!cancelled) {
-        setIsPreloaded(true);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    warmCachedImageUrls(cachedImages.slice(1));
   }, [cachedImages, hasImages]);
 
   useEffect(() => {
-    if (!hasImages || !isPreloaded || isOpen || imageCount <= 1) {
+    if (!hasImages || isOpen || imageCount <= 1) {
       return;
     }
     if (!window.matchMedia("(min-width: 1280px) and (pointer: fine)").matches) {
@@ -99,7 +80,7 @@ export function useCarouselController({
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [hasImages, imageCount, isOpen, isPreloaded]);
+  }, [hasImages, imageCount, isOpen]);
 
   useEffect(() => {
     const thumb = activeThumbRef.current;
@@ -242,7 +223,7 @@ export function useCarouselController({
     activeThumbRef,
     thumbStripRef,
     thumbPlacement,
-    isPreloaded,
+    isPreloaded: true,
     isOpen,
     zoom,
     offset,


### PR DESCRIPTION
## Summary
- 모바일 제휴 상세 LCP 경로에서 전체 이미지 preload 대기와 리뷰 선로딩을 제거했습니다.
- 홈 첫 화면 카드 렌더 수를 제한하고 카드/상세 이미지가 Next image 최적화 경로를 타게 했습니다.
- 관리자 로그 검색 debounce와 협력사 계정 연결 계산 사전 처리로 INP 부담을 줄였습니다.

## Related Issue
Refs #32

## Branch Flow
- base: `dev`
- head: `perf/mobile-ux-rendering`

## Changes
- `PartnerImageCarousel`에서 첫 이미지를 즉시 렌더하고 라이트박스를 지연 로드
- `PartnerDetailReviews` Suspense 서버 섹션 추가
- 홈 파트너 카드 최초 12개 렌더 및 더 보기 확장
- 관리자 로그 검색 debounce 적용 및 오래된 fetch 응답 guard 추가
- 협력사 계정 연결 계산을 상위에서 사전 구성

## Test Plan
- [x] `npx eslint <changed-files>`
- [x] `node --import ./tests/alias-register.mjs --test tests/partner-counts.test.mts tests/partner-portal.mock.test.mts tests/partner-review-reactions.test.mts tests/admin-log-loading-strategy.test.mts`
- [x] `npm run build`
- [x] `npm run release` gates: `build-storybook`, `test-storybook`
- [!] `npx tsc --noEmit --pretty false`는 기존 테스트 타입 오류로 실패했으며, 이번 변경 관련 오류는 `npm run build` 타입 단계와 집중 테스트에서 검증했습니다.

## Checklist
- [x] Diff reviewed
- [x] Focused verification run
- [x] No secrets or auth boundary changes