### PR TITLE
release: 이벤트 종료 및 추첨권 운영 배포

### DIFF
--- a/docs/design-system/elements.md
+++ b/docs/design-system/elements.md
@@ -5,6 +5,8 @@
 - 보조 이동은 `ghost` 또는 `secondary`
 - 위험 액션은 `danger`
 - 정보 강조용 정적 액션은 `soft`
+- 선택된 조작 요소(active tab/filter/nav)는 `primary-soft`가 아니라 `bg-primary text-primary-foreground border-primary` 계열로 표시한다.
+- `primary-soft text-primary`는 badge, info message, soft CTA처럼 선택 상태가 아닌 낮은 강조에만 사용한다.
 
 ## Inputs
 - control radius 통일
@@ -20,6 +22,7 @@
 ## Tabs
 - 탭은 콘텐츠 정책이나 뷰 모드를 분리할 때만 사용한다
 - 모바일에서도 두 줄 난잡함이 생기지 않도록 label 길이를 제한한다
+- 선택 상태는 색상 대비, border, 가능하면 `aria-pressed`/`aria-current`와 아이콘/indicator를 함께 사용해 다크모드에서도 구분되게 한다.
 
 ## Feedback
 - 짧은 폼 메시지는 `FormMessage`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.9.25",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.9.25",
+      "version": "1.10.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.9.25",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/(site)/events/[slug]/page.tsx
+++ b/src/app/(site)/events/[slug]/page.tsx
@@ -6,7 +6,10 @@ import Container from "@/components/ui/Container";
 import Card from "@/components/ui/Card";
 import { getHeaderSession } from "@/lib/header-session";
 import { getEventPageDefinition, listEventPageDefinitions } from "@/lib/event-pages";
-import { getManagedEventCampaign } from "@/lib/promotions/events";
+import {
+  getManagedEventCampaign,
+  isPromotionCampaignVisible,
+} from "@/lib/promotions/events";
 import { getEventRewardSummary } from "@/lib/promotions/event-rewards";
 import { buildSiteUrl, createCanonicalAlternates } from "@/lib/seo";
 import { SITE_NAME } from "@/lib/site";
@@ -31,6 +34,7 @@ export async function generateMetadata({
   const registration = await getManagedEventCampaign(slug);
   const campaign = registration ?? definition;
   const canonicalPath = registration?.pagePath ?? `/events/${campaign.slug}`;
+  const visible = registration ? isPromotionCampaignVisible(registration) : false;
 
   return {
     title: `${campaign.title} | ${SITE_NAME}`,
@@ -59,7 +63,7 @@ export async function generateMetadata({
       images: [campaign.heroImageSrc],
     },
     robots: {
-      index: Boolean(registration?.source === "database" && registration.isActive),
+      index: visible,
       follow: true,
     },
   };
@@ -77,11 +81,16 @@ export default async function EventPage({
   }
   const registration = await getManagedEventCampaign(slug);
   const campaign = registration ?? definition;
+  if (!registration || !isPromotionCampaignVisible(registration)) {
+    notFound();
+  }
   const canonicalPath = registration?.pagePath ?? `/events/${campaign.slug}`;
 
   const session = await getSignedUserSession();
   const rewardsEnabled = Boolean(
-    registration?.source === "database" && registration.id && registration.isActive,
+    registration?.source === "database" &&
+      registration.id &&
+      isPromotionCampaignVisible(registration),
   );
   const [headerSession, summary] = await Promise.all([
     getHeaderSession(session?.userId ?? undefined),

--- a/src/app/(site)/events/[slug]/winner-form/page.tsx
+++ b/src/app/(site)/events/[slug]/winner-form/page.tsx
@@ -1,0 +1,82 @@
+import { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import Container from "@/components/ui/Container";
+import SiteHeader from "@/components/SiteHeader";
+import { getEventPageDefinition } from "@/lib/event-pages";
+import { getEventRewardWinnerGuide } from "@/lib/promotions/event-rewards";
+import { getHeaderSession } from "@/lib/header-session";
+import { getSignedUserSession } from "@/lib/user-auth";
+import { SITE_NAME } from "@/lib/site";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: `당첨 안내 | ${SITE_NAME}`,
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default async function EventWinnerFormPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const definition = getEventPageDefinition(slug);
+  if (!definition) {
+    notFound();
+  }
+
+  const session = await getSignedUserSession();
+  if (!session?.userId) {
+    redirect("/auth/login");
+  }
+
+  const [headerSession, guide] = await Promise.all([
+    getHeaderSession(session.userId),
+    getEventRewardWinnerGuide({
+      eventSlug: slug,
+      memberId: session.userId,
+    }),
+  ]);
+
+  if (!guide) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <SiteHeader initialSession={headerSession} />
+      <main>
+        <Container className="pb-16 pt-8 sm:pt-10" size="narrow">
+          <Card tone="elevated" className="grid gap-5">
+            <div>
+              <p className="ui-kicker">Winner</p>
+              <h1 className="mt-2 text-2xl font-semibold text-foreground">
+                {definition.shortTitle} 당첨 안내
+              </h1>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {guide.rank}번째 당첨자로 확정되었습니다. 기프티콘 발송을 위해 아래 구글폼에 정보를 입력해 주세요.
+              </p>
+            </div>
+            <div className="rounded-[1rem] border border-border/70 bg-surface-inset px-4 py-3 text-sm text-muted-foreground">
+              보유 추첨권 {guide.ticketCount.toLocaleString()}장 기준으로 추첨되었습니다.
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button href={guide.googleFormUrl} target="_blank" className="w-full sm:w-auto">
+                구글폼 작성
+              </Button>
+              <Button href={`/events/${slug}`} variant="secondary" className="w-full sm:w-auto">
+                이벤트 보기
+              </Button>
+            </div>
+          </Card>
+        </Container>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/_actions/promotion-actions.ts
+++ b/src/app/admin/(protected)/_actions/promotion-actions.ts
@@ -2,13 +2,19 @@
 
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { requireAdmin } from "@/lib/auth";
+import { getAdminSession, requireAdmin } from "@/lib/auth";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import {
   DEFAULT_PROMOTION_AUDIENCES,
   type PromotionAudience,
 } from "@/lib/promotions/catalog";
 import { getEventPageDefinition } from "@/lib/event-pages";
+import {
+  createStoredEventRewardDraw,
+  normalizeEventRewardDrawRequest,
+  sendEventRewardWinnerNotifications,
+} from "@/lib/promotions/event-rewards";
+import { getManagedEventCampaign } from "@/lib/promotions/events";
 import {
   deletePromotionSlideImageUrls,
   uploadPromotionSlideImageFile,
@@ -113,6 +119,7 @@ type PromotionSlideDraftPayload = {
   isActive: boolean;
   audiences: PromotionAudience[];
   allowedCampuses: string[];
+  eventSlug: string | null;
 };
 
 function normalizeStringArray(value: unknown) {
@@ -139,6 +146,11 @@ function normalizePromotionAudiences(value: unknown) {
   return audiences.length > 0 ? audiences : [...DEFAULT_PROMOTION_AUDIENCES];
 }
 
+function extractEventSlugFromHref(href: string) {
+  const match = href.match(/^\/events\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:[/?#]|$)/);
+  return match?.[1] ?? null;
+}
+
 function parsePromotionSlideDrafts(formData: FormData) {
   const raw = getRequiredString(formData, "slidesJson");
   let parsed: unknown;
@@ -160,16 +172,27 @@ function parsePromotionSlideDrafts(formData: FormData) {
     if (!id) {
       throw new Error("광고 카드 식별자가 필요합니다.");
     }
+    const href = typeof record.href === "string" ? record.href.trim() : "";
+    const derivedEventSlug = extractEventSlugFromHref(href);
+    const rawEventSlug =
+      typeof record.eventSlug === "string" && record.eventSlug.trim()
+        ? normalizeSlug(record.eventSlug)
+        : null;
+    const eventSlug =
+      derivedEventSlug && (!rawEventSlug || rawEventSlug === derivedEventSlug)
+        ? derivedEventSlug
+        : null;
     return {
       id,
       title: typeof record.title === "string" ? record.title.trim() : "",
       subtitle: typeof record.subtitle === "string" ? record.subtitle.trim() : "",
       imageSrc: typeof record.imageSrc === "string" ? record.imageSrc.trim() : "",
       imageAlt: typeof record.imageAlt === "string" ? record.imageAlt.trim() : "",
-      href: typeof record.href === "string" ? record.href.trim() : "",
+      href,
       isActive: record.isActive === true,
       audiences: normalizePromotionAudiences(record.audiences),
       allowedCampuses: normalizeStringArray(record.allowedCampuses),
+      eventSlug,
     };
   });
   const ids = new Set(slides.map((slide) => slide.id));
@@ -317,6 +340,7 @@ export async function savePromotionSlidesAction(formData: FormData) {
     is_active: boolean;
     audiences: PromotionAudience[];
     allowed_campuses: string[];
+    event_slug: string | null;
   }> = [];
   const removedImageUrls = new Set<string>();
   const nextImageUrls = new Set<string>();
@@ -357,6 +381,7 @@ export async function savePromotionSlidesAction(formData: FormData) {
       is_active: slide.isActive,
       audiences: slide.audiences,
       allowed_campuses: slide.allowedCampuses,
+      event_slug: slide.eventSlug,
     });
     keepIds.add(slide.id);
     nextImageUrls.add(imageSrc);
@@ -408,4 +433,58 @@ export async function savePromotionSlidesAction(formData: FormData) {
 
   revalidateAdvertisementPaths();
   redirect("/admin/advertisement?status=updated");
+}
+
+export async function createEventRewardDrawAction(formData: FormData) {
+  await requireAdmin();
+  const slug = normalizeSlug(getRequiredString(formData, "slug"));
+  const definition = getEventPageDefinition(slug);
+  if (!definition) {
+    throw new Error("이벤트 정의를 찾을 수 없습니다.");
+  }
+  const campaign = (await getManagedEventCampaign(slug)) ?? definition;
+  const request = normalizeEventRewardDrawRequest({
+    winnerCount: getRequiredString(formData, "winnerCount"),
+    seed: getString(formData, "seed"),
+    googleFormUrl: getRequiredString(formData, "googleFormUrl"),
+  });
+  const adminSession = await getAdminSession();
+  const draw = await createStoredEventRewardDraw({
+    campaign,
+    request,
+    createdByAdminId: adminSession?.adminId ?? process.env.ADMIN_ID ?? null,
+  });
+
+  await logAdminAction("event_reward_draw_create", {
+    targetType: "event_reward_draw",
+    targetId: draw.id,
+    properties: {
+      eventSlug: slug,
+      winnerCount: draw.winnerCount,
+      candidateCount: draw.candidateCount,
+      totalTickets: draw.totalTickets,
+    },
+  });
+  revalidatePromotionPaths(slug);
+  redirect(`/admin/event/${slug}?status=draw-created`);
+}
+
+export async function sendEventRewardWinnerNotificationsAction(formData: FormData) {
+  await requireAdmin();
+  const slug = normalizeSlug(getRequiredString(formData, "slug"));
+  const drawId = getRequiredString(formData, "drawId");
+  const result = await sendEventRewardWinnerNotifications(drawId);
+
+  await logAdminAction("event_reward_winner_notification_send", {
+    targetType: "event_reward_draw",
+    targetId: drawId,
+    properties: {
+      eventSlug: slug,
+      status: result.status,
+      notificationId: result.notificationId,
+      warnings: result.warnings.length,
+    },
+  });
+  revalidatePromotionPaths(slug);
+  redirect(`/admin/event/${slug}?status=winner-sent`);
 }

--- a/src/app/admin/(protected)/advertisement/page.tsx
+++ b/src/app/admin/(protected)/advertisement/page.tsx
@@ -7,6 +7,7 @@ import ShellHeader from "@/components/ui/ShellHeader";
 import StatsRow from "@/components/ui/StatsRow";
 import { savePromotionSlidesAction } from "@/app/admin/(protected)/_actions/promotion-actions";
 import {
+  getPromotionCampaignState,
   listManagedEventCampaigns,
   listManagedPromotionSlides,
 } from "@/lib/promotions/events";
@@ -41,9 +42,10 @@ export default async function AdminAdvertisementPage({
     listManagedEventCampaigns({ includeInactive: false }),
   ]);
   const eventPageOptions = eventCampaigns
-    .filter((campaign) => campaign.isActive)
+    .filter((campaign) => getPromotionCampaignState(campaign).key === "active")
     .map((campaign) => ({
       href: campaign.pagePath,
+      slug: campaign.slug,
       label: `${campaign.title} (${campaign.pagePath})`,
     }));
   const activeSlides = slides.filter((slide) => slide.isActive).length;

--- a/src/app/admin/(protected)/event/[slug]/page.tsx
+++ b/src/app/admin/(protected)/event/[slug]/page.tsx
@@ -8,18 +8,28 @@ import FormMessage from "@/components/ui/FormMessage";
 import ShellHeader from "@/components/ui/ShellHeader";
 import StatsRow from "@/components/ui/StatsRow";
 import {
+  createEventRewardDrawAction,
   createPromotionEventAction,
   deletePromotionEventAction,
+  sendEventRewardWinnerNotificationsAction,
   updatePromotionEventAction,
 } from "@/app/admin/(protected)/_actions/promotion-actions";
 import { getEventPageDefinition } from "@/lib/event-pages";
-import { PROMOTION_AUDIENCE_OPTIONS } from "@/lib/promotions/catalog";
+import { PROMOTION_AUDIENCE_OPTIONS, type EventCampaign } from "@/lib/promotions/catalog";
 import {
+  buildEventRewardAdminOverview,
+  buildEventRewardComparisonOverview,
   getEventRewardAdminOverview,
+  getLatestEventRewardDrawWithWinners,
   type EventRewardAdminMemberRow,
   type EventRewardAdminOverview,
+  type EventRewardStoredDraw,
 } from "@/lib/promotions/event-rewards";
-import { listManagedEventCampaigns, type ManagedEventCampaign } from "@/lib/promotions/events";
+import {
+  getPromotionCampaignState,
+  listManagedEventCampaigns,
+  type ManagedEventCampaign,
+} from "@/lib/promotions/events";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +42,12 @@ function statusMessage(status?: string) {
   }
   if (status === "deleted") {
     return "이벤트를 삭제했습니다.";
+  }
+  if (status === "draw-created") {
+    return "추첨 결과를 확정했습니다.";
+  }
+  if (status === "winner-sent") {
+    return "당첨 안내를 발송했습니다.";
   }
   return null;
 }
@@ -51,37 +67,14 @@ function formatEventDate(value: string) {
 }
 
 function getEventState(campaign: ManagedEventCampaign | null) {
-  if (!campaign || campaign.source !== "database" || !campaign.id) {
-    return {
-      label: "등록 필요",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  if (!campaign.isActive) {
-    return {
-      label: "비활성",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  const now = Date.now();
-  const startsAt = new Date(campaign.startsAt).getTime();
-  const endsAt = new Date(campaign.endsAt).getTime();
-  if (Number.isFinite(startsAt) && now < startsAt) {
-    return {
-      label: "진행 전",
-      className: "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-200",
-    };
-  }
-  if (Number.isFinite(endsAt) && now > endsAt) {
-    return {
-      label: "진행 후",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  return {
-    label: "진행 중",
-    className: "border-primary/20 bg-primary-soft text-primary",
-  };
+  const state = getPromotionCampaignState(campaign);
+  const className =
+    state.key === "active"
+      ? "border-primary bg-primary text-primary-foreground"
+      : state.key === "upcoming"
+        ? "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-200"
+        : "border-border bg-surface-inset text-muted-foreground";
+  return { label: state.label, className };
 }
 
 function rewardConditionLabel(
@@ -116,10 +109,17 @@ function RewardStatusPill({
 }
 
 function SignupRewardOverviewSection({
+  campaign,
   overview,
+  draw,
+  warningMessage,
 }: {
+  campaign: EventCampaign;
   overview: EventRewardAdminOverview;
+  draw: EventRewardStoredDraw | null;
+  warningMessage?: string | null;
 }) {
+  const comparison = buildEventRewardComparisonOverview(campaign, overview.members);
   const conditionStats = [
     { label: "회원가입", value: `${overview.conditionCounts.signup ?? 0}명` },
     { label: "MM 알림", value: `${overview.conditionCounts.mm ?? 0}명` },
@@ -142,6 +142,12 @@ function SignupRewardOverviewSection({
         <Button href="/admin/event/signup-reward/rewards/export" variant="secondary">
           CSV 내보내기
         </Button>
+        <Button
+          href="/admin/event/signup-reward/rewards/export?kind=comparison"
+          variant="secondary"
+        >
+          전후 비교 CSV
+        </Button>
       </div>
 
       <StatsRow
@@ -150,9 +156,129 @@ function SignupRewardOverviewSection({
           { label: "총 추첨권", value: `${overview.totalTickets.toLocaleString()}장`, hint: "현재 조건 기준" },
           { label: "리뷰 인정", value: `${overview.reviewCount.toLocaleString()}개`, hint: "이벤트 기간 visible 리뷰" },
           { label: "가입 완료", value: `${(overview.conditionCounts.signup ?? 0).toLocaleString()}명`, hint: "종료 전 가입자" },
+          { label: "확인가능 증가", value: `${comparison.totalKnownTicketDelta.toLocaleString()}장`, hint: "before 복원 가능분 기준" },
         ]}
         minItemWidth="13rem"
       />
+      {warningMessage ? (
+        <FormMessage variant="error">{warningMessage}</FormMessage>
+      ) : null}
+
+      <Card tone="elevated" className="grid gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="ui-kicker">Draw</p>
+            <h3 className="mt-2 text-xl font-semibold text-foreground">
+              가중 추첨
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              추첨권 수만큼 확률을 부여하되 한 회원은 최대 1회만 당첨됩니다.
+            </p>
+          </div>
+          {draw ? (
+            <span className="rounded-full border border-primary bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground">
+              {draw.status}
+            </span>
+          ) : null}
+        </div>
+
+        {draw ? (
+          <div className="grid gap-4">
+            <StatsRow
+              items={[
+                { label: "당첨자", value: `${draw.winners.length.toLocaleString()}명`, hint: "확정 결과" },
+                { label: "후보", value: `${draw.candidateCount.toLocaleString()}명`, hint: "추첨권 1장 이상" },
+                { label: "총 추첨권", value: `${draw.totalTickets.toLocaleString()}장`, hint: "추첨 시점" },
+                { label: "Seed", value: draw.seed.slice(0, 12), hint: "재현용" },
+              ]}
+              minItemWidth="11rem"
+            />
+            <div className="overflow-x-auto rounded-[1rem] border border-border/70">
+              <table className="w-full min-w-[720px] text-left text-sm">
+                <thead className="border-b border-border bg-surface-inset text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-3">순위</th>
+                    <th className="px-4 py-3">회원</th>
+                    <th className="px-4 py-3">기수/캠퍼스</th>
+                    <th className="px-4 py-3 text-right">추첨권</th>
+                    <th className="px-4 py-3">알림</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {draw.winners.map((winner) => (
+                    <tr key={winner.id}>
+                      <td className="px-4 py-3 font-semibold text-foreground">
+                        {winner.rank}
+                      </td>
+                      <td className="px-4 py-3">
+                        <p className="font-semibold text-foreground">
+                          {winner.displayName || winner.mmUsername}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {winner.mmUsername}
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {winner.year}기 · {winner.campus || "-"}
+                      </td>
+                      <td className="px-4 py-3 text-right font-semibold text-foreground">
+                        {winner.ticketCount.toLocaleString()}장
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {winner.notificationStatus}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {!draw.sentAt ? (
+              <form action={sendEventRewardWinnerNotificationsAction} className="flex justify-end">
+                <input type="hidden" name="slug" value="signup-reward" />
+                <input type="hidden" name="drawId" value={draw.id} />
+                <Button type="submit">앱+MM+푸시 발송</Button>
+              </form>
+            ) : null}
+          </div>
+        ) : (
+          <form action={createEventRewardDrawAction} className="grid gap-4">
+            <div className="grid gap-3 sm:grid-cols-[12rem_minmax(0,1fr)]">
+              <label className="grid gap-2 text-sm font-medium text-foreground">
+                당첨 인원
+                <input
+                  name="winnerCount"
+                  type="number"
+                  min="1"
+                  required
+                  className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground"
+                />
+              </label>
+              <label className="grid gap-2 text-sm font-medium text-foreground">
+                구글폼 링크
+                <input
+                  name="googleFormUrl"
+                  type="url"
+                  required
+                  placeholder="https://docs.google.com/forms/..."
+                  className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground"
+                />
+              </label>
+            </div>
+            <label className="grid gap-2 text-sm font-medium text-foreground">
+              Seed 선택 입력
+              <input
+                name="seed"
+                placeholder="비워두면 자동 생성"
+                className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground"
+              />
+            </label>
+            <input type="hidden" name="slug" value="signup-reward" />
+            <div className="flex justify-end">
+              <Button type="submit">추첨 확정</Button>
+            </div>
+          </form>
+        )}
+      </Card>
 
       <Card tone="muted" className="grid gap-3">
         <div className="flex flex-wrap gap-2">
@@ -242,10 +368,24 @@ export default async function AdminEventDetailPage({
   const registration = campaigns.find((campaign) => campaign.slug === slug) ?? null;
   const campaign = registration ?? definition;
   const isRegistered = registration?.source === "database" && Boolean(registration.id);
-  const state = getEventState(registration);
+  const state = getEventState(isRegistered ? registration : null);
   const message = statusMessage(paramsData.status);
-  const rewardOverview =
-    slug === "signup-reward" ? await getEventRewardAdminOverview(campaign) : null;
+  let rewardOverview: EventRewardAdminOverview | null = null;
+  let rewardDraw: EventRewardStoredDraw | null = null;
+  let rewardWarningMessage: string | null = null;
+  if (slug === "signup-reward") {
+    try {
+      [rewardOverview, rewardDraw] = await Promise.all([
+        getEventRewardAdminOverview(campaign),
+        getLatestEventRewardDrawWithWinners(slug),
+      ]);
+    } catch (error) {
+      console.error("[admin-event] reward overview query failed", error);
+      rewardOverview = buildEventRewardAdminOverview(campaign, []);
+      rewardWarningMessage =
+        "추첨권 현황 데이터를 불러오지 못했습니다. Supabase 연결과 이벤트 보상 테이블 상태를 확인해 주세요.";
+    }
+  }
   const targetLabel =
     registration?.targetAudiences?.map(
       (audience) => PROMOTION_AUDIENCE_OPTIONS.find((option) => option.key === audience)?.label ?? audience,
@@ -380,7 +520,12 @@ export default async function AdminEventDetailPage({
         </div>
 
         {rewardOverview ? (
-          <SignupRewardOverviewSection overview={rewardOverview} />
+          <SignupRewardOverviewSection
+            campaign={campaign}
+            overview={rewardOverview}
+            draw={rewardDraw}
+            warningMessage={rewardWarningMessage}
+          />
         ) : null}
       </div>
     </AdminShell>

--- a/src/app/admin/(protected)/event/page.tsx
+++ b/src/app/admin/(protected)/event/page.tsx
@@ -6,7 +6,11 @@ import ShellHeader from "@/components/ui/ShellHeader";
 import StatsRow from "@/components/ui/StatsRow";
 import { listEventPageDefinitions } from "@/lib/event-pages";
 import { PROMOTION_AUDIENCE_OPTIONS } from "@/lib/promotions/catalog";
-import { listManagedEventCampaigns, type ManagedEventCampaign } from "@/lib/promotions/events";
+import {
+  getPromotionCampaignState,
+  listManagedEventCampaigns,
+  type ManagedEventCampaign,
+} from "@/lib/promotions/events";
 
 export const dynamic = "force-dynamic";
 
@@ -32,37 +36,14 @@ function formatEventDate(value: string) {
 }
 
 function getEventState(campaign: ManagedEventCampaign | null) {
-  if (!campaign || campaign.source !== "database" || !campaign.id) {
-    return {
-      label: "등록 필요",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  if (!campaign.isActive) {
-    return {
-      label: "비활성",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  const now = Date.now();
-  const startsAt = new Date(campaign.startsAt).getTime();
-  const endsAt = new Date(campaign.endsAt).getTime();
-  if (Number.isFinite(startsAt) && now < startsAt) {
-    return {
-      label: "진행 전",
-      className: "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-200",
-    };
-  }
-  if (Number.isFinite(endsAt) && now > endsAt) {
-    return {
-      label: "진행 후",
-      className: "border-border bg-surface-inset text-muted-foreground",
-    };
-  }
-  return {
-    label: "진행 중",
-    className: "border-primary/20 bg-primary-soft text-primary",
-  };
+  const state = getPromotionCampaignState(campaign);
+  const className =
+    state.key === "active"
+      ? "border-primary bg-primary text-primary-foreground"
+      : state.key === "upcoming"
+        ? "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-200"
+        : "border-border bg-surface-inset text-muted-foreground";
+  return { label: state.label, className };
 }
 
 function EventPill({
@@ -87,7 +68,7 @@ function EventCard({
   registration: ManagedEventCampaign | null;
 }) {
   const isRegistered = registration?.source === "database" && Boolean(registration.id);
-  const state = getEventState(registration);
+  const state = getEventState(isRegistered ? registration : null);
   const periodStarts = formatEventDate(registration?.startsAt ?? definition.startsAt);
   const periodEnds = formatEventDate(registration?.endsAt ?? definition.endsAt);
   const targetLabel =
@@ -172,7 +153,8 @@ export default async function AdminEventPage({
       bucket,
       items: definitions.filter((definition) => {
         const registration = registrationMap.get(definition.slug) ?? null;
-        if (!registration) {
+        const isRegistered = registration?.source === "database" && Boolean(registration.id);
+        if (!isRegistered) {
           return bucket === "등록 필요";
         }
         return getEventState(registration).label === bucket;

--- a/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
+++ b/src/app/admin/(protected)/event/signup-reward/rewards/export/route.ts
@@ -1,7 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth";
 import { getEventPageDefinition } from "@/lib/event-pages";
 import {
+  buildEventRewardComparisonOverview,
+  createEventRewardComparisonCsv,
   createEventRewardCsv,
   getEventRewardAdminOverview,
 } from "@/lib/promotions/event-rewards";
@@ -9,7 +11,7 @@ import { getManagedEventCampaign } from "@/lib/promotions/events";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   await requireAdmin();
 
   const definition = getEventPageDefinition("signup-reward");
@@ -19,12 +21,22 @@ export async function GET() {
 
   const campaign = (await getManagedEventCampaign("signup-reward")) ?? definition;
   const overview = await getEventRewardAdminOverview(campaign);
-  const csv = createEventRewardCsv(overview);
+  const kind = request.nextUrl.searchParams.get("kind");
+  const csv =
+    kind === "comparison"
+      ? createEventRewardComparisonCsv(
+          buildEventRewardComparisonOverview(campaign, overview.members),
+        )
+      : createEventRewardCsv(overview);
+  const filename =
+    kind === "comparison"
+      ? "signup-reward-comparison.csv"
+      : "signup-reward-rewards.csv";
 
   return new NextResponse(csv, {
     headers: {
       "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": 'attachment; filename="signup-reward-rewards.csv"',
+      "Content-Disposition": `attachment; filename="${filename}"`,
       "Cache-Control": "no-store",
     },
   });

--- a/src/app/api/cron/archive-expired-promotions/route.ts
+++ b/src/app/api/cron/archive-expired-promotions/route.ts
@@ -1,0 +1,90 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+import { isAdminSession } from "@/lib/auth";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+function isAuthorizedByCronSecret(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return false;
+  }
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: NextRequest) {
+  const adminAuthorized = await isAdminSession();
+  if (!adminAuthorized && !isAuthorizedByCronSecret(request)) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const nowIso = new Date().toISOString();
+  const { data: expiredEvents, error: eventQueryError } = await supabase
+    .from("promotion_events")
+    .select("slug")
+    .eq("is_active", true)
+    .lt("ends_at", nowIso);
+
+  if (eventQueryError) {
+    return NextResponse.json(
+      { ok: false, message: eventQueryError.message },
+      { status: 500 },
+    );
+  }
+
+  const slugs = (expiredEvents ?? [])
+    .map((event) => String(event.slug ?? "").trim())
+    .filter(Boolean);
+
+  if (slugs.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      archivedEvents: 0,
+      archivedSlides: 0,
+      archivedAt: nowIso,
+    });
+  }
+
+  const { error: eventUpdateError } = await supabase
+    .from("promotion_events")
+    .update({ is_active: false })
+    .in("slug", slugs);
+  if (eventUpdateError) {
+    return NextResponse.json(
+      { ok: false, message: eventUpdateError.message },
+      { status: 500 },
+    );
+  }
+
+  const { data: updatedSlides, error: slideUpdateError } = await supabase
+    .from("promotion_slides")
+    .update({ is_active: false })
+    .in("event_slug", slugs)
+    .eq("is_active", true)
+    .select("id");
+  if (slideUpdateError) {
+    return NextResponse.json(
+      { ok: false, message: slideUpdateError.message },
+      { status: 500 },
+    );
+  }
+
+  revalidatePath("/");
+  revalidatePath("/admin");
+  revalidatePath("/admin/advertisement");
+  revalidatePath("/admin/event");
+  for (const slug of slugs) {
+    revalidatePath(`/events/${slug}`);
+    revalidatePath(`/admin/event/${slug}`);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    archivedEvents: slugs.length,
+    archivedSlides: updatedSlides?.length ?? 0,
+    slugs,
+    archivedAt: nowIso,
+  });
+}

--- a/src/components/CategoryTabs.tsx
+++ b/src/components/CategoryTabs.tsx
@@ -1,3 +1,4 @@
+import { CheckIcon } from "@heroicons/react/20/solid";
 import type { CategoryKey } from "@/lib/types";
 import { cn } from "@/lib/cn";
 
@@ -24,25 +25,33 @@ export default function CategoryTabs({
           <button
             key={option.key}
             type="button"
+            aria-pressed={isActive}
             onClick={() => onChange(option.key)}
             className={cn(
-              "flex min-h-11 min-w-11 flex-col gap-0.5 rounded-[1rem] border px-4 py-2.5 text-left transition-surface duration-200 ease-out",
+              "flex min-h-11 min-w-11 items-start gap-2 rounded-[1rem] border px-4 py-2.5 text-left transition-surface duration-200 ease-out",
               isActive
-                ? "border-primary/20 bg-primary-soft text-primary shadow-flat"
+                ? "border-primary bg-primary text-primary-foreground shadow-raised"
                 : "border-border/80 bg-surface-control text-foreground shadow-flat hover:border-strong hover:bg-surface-elevated",
             )}
           >
-            <span className="text-sm font-semibold">{option.label}</span>
-            {option.description ? (
-              <span
-                className={cn(
-                  "text-xs leading-5",
-                  isActive ? "text-primary/80" : "text-muted-foreground",
-                )}
-              >
-                {option.description}
+            {isActive ? (
+              <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary-foreground/18 text-primary-foreground">
+                <CheckIcon className="h-3 w-3" aria-hidden="true" />
               </span>
             ) : null}
+            <span className="grid gap-0.5">
+              <span className="text-sm font-semibold">{option.label}</span>
+              {option.description ? (
+                <span
+                  className={cn(
+                    "text-xs leading-5",
+                    isActive ? "text-primary-foreground/80" : "text-muted-foreground",
+                  )}
+                >
+                  {option.description}
+                </span>
+              ) : null}
+            </span>
           </button>
         );
       })}

--- a/src/components/admin/AdminShellView.tsx
+++ b/src/components/admin/AdminShellView.tsx
@@ -66,16 +66,16 @@ export default function AdminShellView({
                   className={cn(
                     "group flex items-center gap-3 rounded-2xl border px-3 py-3 text-sm transition-colors",
                     active
-                      ? "border-primary/30 bg-primary/10 text-foreground"
+                      ? "border-primary bg-primary text-primary-foreground shadow-raised"
                       : "border-transparent bg-transparent text-muted-foreground hover:border-border hover:bg-surface-elevated hover:text-foreground",
                     expanded ? "justify-start" : "justify-center px-2.5",
                   )}
                 >
-                  <Icon className={cn("h-5 w-5 shrink-0", active ? "text-primary" : "text-muted-foreground group-hover:text-foreground")} />
+                  <Icon className={cn("h-5 w-5 shrink-0", active ? "text-primary-foreground" : "text-muted-foreground group-hover:text-foreground")} />
                   {expanded ? (
                     <span className="grid min-w-0 gap-0.5">
-                      <span className="truncate font-semibold text-foreground">{item.label}</span>
-                      <span className="truncate text-xs text-muted-foreground">{item.description}</span>
+                      <span className={cn("truncate font-semibold", active ? "text-primary-foreground" : "text-foreground")}>{item.label}</span>
+                      <span className={cn("truncate text-xs", active ? "text-primary-foreground/80" : "text-muted-foreground")}>{item.description}</span>
                     </span>
                   ) : (
                     <span className="sr-only">{item.label}</span>

--- a/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
+++ b/src/components/admin/promotion-carousel-editor/PromotionCarouselEditor.tsx
@@ -49,6 +49,7 @@ type SlideDraft = {
   isActive: boolean;
   audiences: PromotionAudience[];
   allowedCampuses: CampusSlug[];
+  eventSlug: string | null;
   source: "database" | "catalog";
 };
 
@@ -59,6 +60,7 @@ type PendingCrop = {
 
 export type PromotionEventPageOption = {
   href: string;
+  slug: string;
   label: string;
 };
 
@@ -113,12 +115,18 @@ function toDraftSlide(slide: ManagedPromotionSlide): SlideDraft {
     audiences:
       slide.audiences.length > 0 ? [...slide.audiences] : [...DEFAULT_PROMOTION_AUDIENCES],
     allowedCampuses,
+    eventSlug: slide.eventSlug,
     source: slide.source,
   };
 }
 
 function getFileInputName(id: string) {
   return `slide_image_${id}`;
+}
+
+function extractEventSlugFromHref(href: string) {
+  const match = href.trim().match(/^\/events\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:[/?#]|$)/);
+  return match?.[1] ?? null;
 }
 
 function loadImageElement(sourceUrl: string) {
@@ -276,6 +284,7 @@ export default function PromotionCarouselEditor({
           isActive: slide.isActive,
           audiences: slide.audiences,
           allowedCampuses: slide.allowedCampuses,
+          eventSlug: slide.eventSlug,
         })),
       ),
     [slides],
@@ -357,6 +366,7 @@ export default function PromotionCarouselEditor({
         isActive: true,
         audiences: [...DEFAULT_PROMOTION_AUDIENCES],
         allowedCampuses: [],
+        eventSlug: null,
         source: "database",
       },
     ]);
@@ -687,7 +697,12 @@ export default function PromotionCarouselEditor({
                           if (!href) {
                             return;
                           }
-                          updateSlide(slide.id, (current) => ({ ...current, href }));
+                          const option = eventPageOptions.find((item) => item.href === href);
+                          updateSlide(slide.id, (current) => ({
+                            ...current,
+                            href,
+                            eventSlug: option?.slug ?? null,
+                          }));
                         }}
                       >
                         <option value="">
@@ -707,9 +722,16 @@ export default function PromotionCarouselEditor({
                       연결 페이지
                       <Input
                         value={slide.href}
-                        onChange={(event) =>
-                          updateSlide(slide.id, (current) => ({ ...current, href: event.target.value }))
-                        }
+                        onChange={(event) => {
+                          const href = event.target.value;
+                          updateSlide(slide.id, (current) => ({
+                            ...current,
+                            href,
+                            eventSlug:
+                              eventPageOptions.find((option) => option.href === href)?.slug ??
+                              extractEventSlugFromHref(href),
+                          }));
+                        }}
                         placeholder="/events/signup-reward"
                         disabled={!editable}
                         className={hrefInvalid ? "border-danger/40 bg-danger/5 focus:border-danger" : undefined}

--- a/src/components/partner/PartnerDashboardView.tsx
+++ b/src/components/partner/PartnerDashboardView.tsx
@@ -150,15 +150,16 @@ function CompanyTabs({
             className={cn(
               "rounded-[1.1rem] border px-4 py-3 text-left transition-surface duration-200 ease-out",
               active
-                ? "border-primary/20 bg-primary-soft text-primary shadow-flat"
+                ? "border-primary bg-primary text-primary-foreground shadow-raised"
                 : "border-border/80 bg-surface-control text-foreground shadow-flat hover:border-strong hover:bg-surface-elevated",
             )}
+            aria-pressed={active}
           >
             <p className="text-sm font-semibold">{company.name}</p>
             <p
               className={cn(
                 "mt-1 text-xs",
-                active ? "text-primary/80" : "text-muted-foreground",
+                active ? "text-primary-foreground/80" : "text-muted-foreground",
               )}
             >
               {company.services.length}개 브랜드

--- a/src/components/partner/PartnerPortalShellView.tsx
+++ b/src/components/partner/PartnerPortalShellView.tsx
@@ -186,7 +186,7 @@ function DashboardSidebar({
                 className={cn(
                   "flex min-h-12 items-center justify-center gap-3 rounded-[1rem] border px-3 text-sm font-semibold transition-surface xl:justify-start",
                   active
-                    ? "border-primary/20 bg-primary-soft text-primary shadow-flat"
+                    ? "border-primary bg-primary text-primary-foreground shadow-raised"
                     : "border-transparent text-muted-foreground hover:border-border hover:bg-surface-control hover:text-foreground",
                 )}
               >
@@ -196,7 +196,7 @@ function DashboardSidebar({
                   <span
                     className={cn(
                       "block truncate text-xs font-medium",
-                      active ? "text-primary/75" : "text-muted-foreground",
+                      active ? "text-primary-foreground/80" : "text-muted-foreground",
                     )}
                   >
                     {item.description}

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -73,6 +73,8 @@ export const ADMIN_AUDIT_ACTIONS = [
   'promotion_slide_update',
   'promotion_slide_delete',
   'promotion_slide_bulk_update',
+  'event_reward_draw_create',
+  'event_reward_winner_notification_send',
 ] as const;
 
 export type AdminAuditAction = (typeof ADMIN_AUDIT_ACTIONS)[number];

--- a/src/lib/image-cache.stories.tsx
+++ b/src/lib/image-cache.stories.tsx
@@ -126,7 +126,7 @@ export const Summary: Story = {
     await expect(canvas.getByText("local:/local.png")).toBeInTheDocument();
     await expect(
       canvas.getByText(
-        "storage:https://project.supabase.co/storage/v1/object/public/partner-media/path/file.webp",
+        "storage:/api/image?url=https%3A%2F%2Fproject.supabase.co%2Fstorage%2Fv1%2Fobject%2Fpublic%2Fpartner-media%2Fpath%2Ffile.webp",
       ),
     ).toBeInTheDocument();
     await expect(canvas.getByText("data:data:image/png;base64,abc")).toBeInTheDocument();

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -1,8 +1,10 @@
+import { createHash, randomBytes } from "node:crypto";
 import { getMemberNotificationPreferences } from "@/lib/notification-preferences";
 import { fetchMemberVisibleReviewCountInRange } from "@/lib/partner-counts";
 import { collectPagedRows } from "@/lib/log-insights/paging";
 import { getPolicyDocumentByKind } from "@/lib/policy-documents";
 import { getPushPreferencesOrDefault } from "@/lib/push";
+import { sendAdminNotificationCampaign } from "@/lib/admin-notification-ops";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import type { EventCampaign, EventConditionKey } from "@/lib/promotions/catalog";
 
@@ -55,6 +57,51 @@ export type EventRewardAdminOverview = {
   members: EventRewardAdminMemberRow[];
 };
 
+export type EventRewardBeforeStatus = EventRewardConditionStatus | "unknown";
+
+export type EventRewardComparisonMemberRow = EventRewardAdminMemberRow & {
+  existedBeforeEvent: boolean;
+  joinedDuringEvent: boolean;
+  beforeKnownTickets: number;
+  afterTickets: number;
+  knownTicketDelta: number;
+  beforeConditions: Partial<Record<EventConditionKey, EventRewardBeforeStatus>>;
+};
+
+export type EventRewardComparisonOverview = {
+  beforeAt: string;
+  afterAt: string;
+  memberCount: number;
+  totalBeforeKnownTickets: number;
+  totalAfterTickets: number;
+  totalKnownTicketDelta: number;
+  members: EventRewardComparisonMemberRow[];
+};
+
+export type EventRewardDrawRequest = {
+  winnerCount: number;
+  seed: string;
+  googleFormUrl: string;
+};
+
+export type EventRewardDrawWinner = {
+  rank: number;
+  memberId: string;
+  displayName: string | null;
+  mmUsername: string;
+  year: number;
+  campus: string | null;
+  ticketCount: number;
+};
+
+export type EventRewardDrawPlan = {
+  seed: string;
+  winnerCount: number;
+  candidateCount: number;
+  totalTickets: number;
+  winners: EventRewardDrawWinner[];
+};
+
 type MemberRow = {
   id: string;
   display_name: string | null;
@@ -75,6 +122,80 @@ type ReviewRow = {
   member_id: string | null;
 };
 
+type EventRewardDrawRow = {
+  id: string;
+  event_slug: string;
+  status: "draft" | "finalized" | "sent" | "partial_failed" | "failed";
+  seed: string;
+  winner_count: number;
+  candidate_count: number;
+  total_tickets: number;
+  google_form_url: string;
+  guide_path: string;
+  sent_notification_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_by_admin_id: string | null;
+  created_at: string;
+  finalized_at: string | null;
+  sent_at: string | null;
+  updated_at: string;
+};
+
+type EventRewardWinnerRow = {
+  id: string;
+  draw_id: string;
+  event_slug: string;
+  member_id: string;
+  winner_rank: number;
+  ticket_count: number;
+  display_name: string | null;
+  mm_username: string | null;
+  year: number | null;
+  campus: string | null;
+  notification_status: "pending" | "sent" | "partial_failed" | "failed" | "skipped";
+  notification_sent_at: string | null;
+  notification_error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type EventRewardStoredWinner = {
+  id: string;
+  drawId: string;
+  eventSlug: string;
+  memberId: string;
+  rank: number;
+  ticketCount: number;
+  displayName: string | null;
+  mmUsername: string;
+  year: number;
+  campus: string | null;
+  notificationStatus: EventRewardWinnerRow["notification_status"];
+  notificationSentAt: string | null;
+  notificationError: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type EventRewardStoredDraw = {
+  id: string;
+  eventSlug: string;
+  status: EventRewardDrawRow["status"];
+  seed: string;
+  winnerCount: number;
+  candidateCount: number;
+  totalTickets: number;
+  googleFormUrl: string;
+  guidePath: string;
+  sentNotificationId: string | null;
+  createdByAdminId: string | null;
+  createdAt: string;
+  finalizedAt: string | null;
+  sentAt: string | null;
+  updatedAt: string;
+  winners: EventRewardStoredWinner[];
+};
+
 function assertEventRewardQuerySucceeded(error: unknown, label: string) {
   if (!error) {
     return;
@@ -89,6 +210,24 @@ function isJoinedByCampaignEnd(value: string | null, campaign: EventCampaign) {
   }
   const time = new Date(value).getTime();
   return Number.isFinite(time) && time <= new Date(campaign.endsAt).getTime();
+}
+
+function isJoinedByCampaignStart(value: string | null, campaign: EventCampaign) {
+  if (!value) {
+    return false;
+  }
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) && time <= new Date(campaign.startsAt).getTime();
+}
+
+function isJoinedDuringCampaign(value: string | null, campaign: EventCampaign) {
+  if (!value) {
+    return false;
+  }
+  const time = new Date(value).getTime();
+  const startsAt = new Date(campaign.startsAt).getTime();
+  const endsAt = new Date(campaign.endsAt).getTime();
+  return Number.isFinite(time) && time > startsAt && time <= endsAt;
 }
 
 export function calculateEventRewardConditions(
@@ -259,6 +398,16 @@ function conditionStatusLabel(
   return condition?.status === "received" ? "완료" : "미완료";
 }
 
+function beforeConditionStatusLabel(value: EventRewardBeforeStatus | undefined) {
+  if (value === "received") {
+    return "완료";
+  }
+  if (value === "missing") {
+    return "미완료";
+  }
+  return "확인불가";
+}
+
 export function createEventRewardCsv(overview: EventRewardAdminOverview) {
   const headers = [
     "이름",
@@ -288,6 +437,248 @@ export function createEventRewardCsv(overview: EventRewardAdminOverview) {
   return `\uFEFF${[headers, ...rows]
     .map((row) => row.map((value) => csvCell(value)).join(","))
     .join("\n")}`;
+}
+
+export function buildEventRewardComparisonOverview(
+  campaign: EventCampaign,
+  members: readonly EventRewardAdminMemberInput[],
+): EventRewardComparisonOverview {
+  const adminOverview = buildEventRewardAdminOverview(campaign, members);
+  const rows = adminOverview.members.map<EventRewardComparisonMemberRow>((member) => {
+    const signupCondition = campaign.conditions.find((condition) => condition.key === "signup");
+    const existedBeforeEvent = isJoinedByCampaignStart(member.createdAt, campaign);
+    const joinedDuringEvent = isJoinedDuringCampaign(member.createdAt, campaign);
+    const beforeConditions: Partial<Record<EventConditionKey, EventRewardBeforeStatus>> = {
+      signup: existedBeforeEvent ? "received" : "missing",
+      mm: "unknown",
+      push: "unknown",
+      marketing: "unknown",
+    };
+    const beforeKnownTickets =
+      beforeConditions.signup === "received" ? signupCondition?.tickets ?? 0 : 0;
+    return {
+      ...member,
+      existedBeforeEvent,
+      joinedDuringEvent,
+      beforeKnownTickets,
+      afterTickets: member.totalTickets,
+      knownTicketDelta: member.totalTickets - beforeKnownTickets,
+      beforeConditions,
+    };
+  });
+
+  return {
+    beforeAt: campaign.startsAt,
+    afterAt: campaign.endsAt,
+    memberCount: rows.length,
+    totalBeforeKnownTickets: rows.reduce((sum, row) => sum + row.beforeKnownTickets, 0),
+    totalAfterTickets: rows.reduce((sum, row) => sum + row.afterTickets, 0),
+    totalKnownTicketDelta: rows.reduce((sum, row) => sum + row.knownTicketDelta, 0),
+    members: rows,
+  };
+}
+
+export function createEventRewardComparisonCsv(
+  overview: EventRewardComparisonOverview,
+) {
+  const headers = [
+    "이름",
+    "MM ID",
+    "기수",
+    "캠퍼스",
+    "이벤트 전 가입",
+    "이벤트 중 가입",
+    "Before 추첨권(확인가능)",
+    "After 추첨권",
+    "증감(확인가능)",
+    "before_signup",
+    "before_mm",
+    "before_push",
+    "before_marketing",
+    "after_signup",
+    "after_mm",
+    "after_push",
+    "after_marketing",
+    "after_review",
+  ];
+  const rows = overview.members.map((member) => [
+    member.displayName ?? "",
+    member.mmUsername,
+    member.year,
+    member.campus ?? "",
+    member.existedBeforeEvent ? "Y" : "N",
+    member.joinedDuringEvent ? "Y" : "N",
+    member.beforeKnownTickets,
+    member.afterTickets,
+    member.knownTicketDelta,
+    beforeConditionStatusLabel(member.beforeConditions.signup),
+    beforeConditionStatusLabel(member.beforeConditions.mm),
+    beforeConditionStatusLabel(member.beforeConditions.push),
+    beforeConditionStatusLabel(member.beforeConditions.marketing),
+    conditionStatusLabel(member, "signup"),
+    conditionStatusLabel(member, "mm"),
+    conditionStatusLabel(member, "push"),
+    conditionStatusLabel(member, "marketing"),
+    conditionStatusLabel(member, "review"),
+  ]);
+
+  return `\uFEFF${[headers, ...rows]
+    .map((row) => row.map((value) => csvCell(value)).join(","))
+    .join("\n")}`;
+}
+
+function hashToIndex(seed: string, round: number, maxExclusive: number) {
+  const digest = createHash("sha256")
+    .update(`${seed}:${round}`)
+    .digest();
+  const value = digest.readUInt32BE(0);
+  return value % maxExclusive;
+}
+
+export function normalizeEventRewardDrawRequest(input: {
+  winnerCount?: unknown;
+  seed?: unknown;
+  googleFormUrl?: unknown;
+}): EventRewardDrawRequest {
+  const winnerCount = Number(input.winnerCount);
+  if (!Number.isInteger(winnerCount) || winnerCount <= 0) {
+    throw new Error("당첨 인원은 1명 이상이어야 합니다.");
+  }
+
+  const rawUrl = String(input.googleFormUrl ?? "").trim();
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("구글폼 링크 형식을 확인해 주세요.");
+  }
+  const host = url.hostname.toLowerCase();
+  const googleFormsHost =
+    host === "forms.gle" ||
+    (host === "docs.google.com" && url.pathname.startsWith("/forms/"));
+  if (url.protocol !== "https:" || !googleFormsHost) {
+    throw new Error("구글폼 HTTPS 링크만 사용할 수 있습니다.");
+  }
+
+  const seed = String(input.seed ?? "").trim() || randomBytes(16).toString("hex");
+  return {
+    winnerCount,
+    seed,
+    googleFormUrl: url.toString(),
+  };
+}
+
+export function createEventRewardDrawPlan(
+  overview: EventRewardAdminOverview,
+  input: {
+    winnerCount: number;
+    seed?: string | null;
+  },
+): EventRewardDrawPlan {
+  const seed = input.seed?.trim() || randomBytes(16).toString("hex");
+  const candidates = overview.members
+    .filter((member) => member.totalTickets > 0)
+    .map((member) => ({ ...member }));
+
+  if (candidates.length === 0) {
+    throw new Error("추첨 가능한 후보가 없습니다.");
+  }
+  if (!Number.isInteger(input.winnerCount) || input.winnerCount <= 0) {
+    throw new Error("당첨 인원은 1명 이상이어야 합니다.");
+  }
+  if (input.winnerCount > candidates.length) {
+    throw new Error("당첨 인원은 추첨 가능한 후보 수를 초과할 수 없습니다.");
+  }
+
+  const totalTickets = candidates.reduce((sum, member) => sum + member.totalTickets, 0);
+  const remaining = [...candidates];
+  const winners: EventRewardDrawWinner[] = [];
+
+  for (let round = 0; round < input.winnerCount; round += 1) {
+    const remainingTickets = remaining.reduce((sum, member) => sum + member.totalTickets, 0);
+    const pickedTicketIndex = hashToIndex(seed, round, remainingTickets);
+    let cursor = 0;
+    const pickedIndex = remaining.findIndex((member) => {
+      cursor += member.totalTickets;
+      return pickedTicketIndex < cursor;
+    });
+    const [winner] = remaining.splice(Math.max(0, pickedIndex), 1);
+    if (!winner) {
+      throw new Error("추첨 결과를 계산하지 못했습니다.");
+    }
+    winners.push({
+      rank: round + 1,
+      memberId: winner.id,
+      displayName: winner.displayName,
+      mmUsername: winner.mmUsername,
+      year: winner.year,
+      campus: winner.campus,
+      ticketCount: winner.totalTickets,
+    });
+  }
+
+  return {
+    seed,
+    winnerCount: input.winnerCount,
+    candidateCount: candidates.length,
+    totalTickets,
+    winners,
+  };
+}
+
+export function canViewEventRewardWinnerForm(params: {
+  memberId?: string | null;
+  winnerMemberIds: readonly string[];
+}) {
+  return Boolean(
+    params.memberId && params.winnerMemberIds.includes(params.memberId),
+  );
+}
+
+function mapWinnerRow(row: EventRewardWinnerRow): EventRewardStoredWinner {
+  return {
+    id: row.id,
+    drawId: row.draw_id,
+    eventSlug: row.event_slug,
+    memberId: row.member_id,
+    rank: row.winner_rank,
+    ticketCount: row.ticket_count,
+    displayName: row.display_name,
+    mmUsername: row.mm_username ?? "",
+    year: row.year ?? 0,
+    campus: row.campus,
+    notificationStatus: row.notification_status,
+    notificationSentAt: row.notification_sent_at,
+    notificationError: row.notification_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapDrawRow(
+  row: EventRewardDrawRow,
+  winners: EventRewardWinnerRow[],
+): EventRewardStoredDraw {
+  return {
+    id: row.id,
+    eventSlug: row.event_slug,
+    status: row.status,
+    seed: row.seed,
+    winnerCount: row.winner_count,
+    candidateCount: row.candidate_count,
+    totalTickets: row.total_tickets,
+    googleFormUrl: row.google_form_url,
+    guidePath: row.guide_path,
+    sentNotificationId: row.sent_notification_id,
+    createdByAdminId: row.created_by_admin_id,
+    createdAt: row.created_at,
+    finalizedAt: row.finalized_at,
+    sentAt: row.sent_at,
+    updatedAt: row.updated_at,
+    winners: winners
+      .map(mapWinnerRow)
+      .sort((left, right) => left.rank - right.rank),
+  };
 }
 
 function normalizePreferences(params: {
@@ -401,4 +792,275 @@ export async function getEventRewardAdminOverview(campaign: EventCampaign) {
       reviewCount: reviewCounts.get(member.id) ?? 0,
     })),
   );
+}
+
+export async function getLatestEventRewardDrawWithWinners(eventSlug: string) {
+  const supabase = getSupabaseAdminClient();
+  const { data: draw, error: drawError } = await supabase
+    .from("event_reward_draws")
+    .select(
+      "id,event_slug,status,seed,winner_count,candidate_count,total_tickets,google_form_url,guide_path,sent_notification_id,metadata,created_by_admin_id,created_at,finalized_at,sent_at,updated_at",
+    )
+    .eq("event_slug", eventSlug)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (drawError) {
+    throw new Error(drawError.message);
+  }
+  if (!draw) {
+    return null;
+  }
+
+  const { data: winners, error: winnerError } = await supabase
+    .from("event_reward_winners")
+    .select(
+      "id,draw_id,event_slug,member_id,winner_rank,ticket_count,display_name,mm_username,year,campus,notification_status,notification_sent_at,notification_error,created_at,updated_at",
+    )
+    .eq("draw_id", draw.id)
+    .order("winner_rank", { ascending: true });
+  if (winnerError) {
+    throw new Error(winnerError.message);
+  }
+
+  return mapDrawRow(
+    draw as EventRewardDrawRow,
+    (winners ?? []) as EventRewardWinnerRow[],
+  );
+}
+
+export async function createStoredEventRewardDraw(params: {
+  campaign: EventCampaign;
+  request: EventRewardDrawRequest;
+  createdByAdminId?: string | null;
+}) {
+  const overview = await getEventRewardAdminOverview(params.campaign);
+  const plan = createEventRewardDrawPlan(overview, {
+    winnerCount: params.request.winnerCount,
+    seed: params.request.seed,
+  });
+  const supabase = getSupabaseAdminClient();
+  const now = new Date().toISOString();
+  const guidePath = `/events/${params.campaign.slug}/winner-form`;
+  const { data: draw, error: drawError } = await supabase
+    .from("event_reward_draws")
+    .insert({
+      event_slug: params.campaign.slug,
+      status: "finalized",
+      seed: plan.seed,
+      winner_count: plan.winnerCount,
+      candidate_count: plan.candidateCount,
+      total_tickets: plan.totalTickets,
+      google_form_url: params.request.googleFormUrl,
+      guide_path: guidePath,
+      created_by_admin_id: params.createdByAdminId ?? null,
+      finalized_at: now,
+      metadata: {
+        campaignTitle: params.campaign.title,
+        campaignStartsAt: params.campaign.startsAt,
+        campaignEndsAt: params.campaign.endsAt,
+      },
+    })
+    .select(
+      "id,event_slug,status,seed,winner_count,candidate_count,total_tickets,google_form_url,guide_path,sent_notification_id,metadata,created_by_admin_id,created_at,finalized_at,sent_at,updated_at",
+    )
+    .single();
+
+  if (drawError) {
+    if (drawError.message.includes("event_reward_draws_one_finalized_per_event")) {
+      throw new Error("이미 확정된 추첨이 있습니다.");
+    }
+    throw new Error(drawError.message);
+  }
+
+  const winnerRows = plan.winners.map((winner) => ({
+    draw_id: draw.id,
+    event_slug: params.campaign.slug,
+    member_id: winner.memberId,
+    winner_rank: winner.rank,
+    ticket_count: winner.ticketCount,
+    display_name: winner.displayName,
+    mm_username: winner.mmUsername,
+    year: winner.year,
+    campus: winner.campus,
+  }));
+
+  const { data: winners, error: winnerError } = await supabase
+    .from("event_reward_winners")
+    .insert(winnerRows)
+    .select(
+      "id,draw_id,event_slug,member_id,winner_rank,ticket_count,display_name,mm_username,year,campus,notification_status,notification_sent_at,notification_error,created_at,updated_at",
+    );
+  if (winnerError) {
+    throw new Error(winnerError.message);
+  }
+
+  return mapDrawRow(
+    draw as EventRewardDrawRow,
+    (winners ?? []) as EventRewardWinnerRow[],
+  );
+}
+
+function drawNotificationStatus(params: {
+  targeted: number;
+  sent: number;
+  failed: number;
+}) {
+  if (params.targeted === 0) {
+    return "skipped" as const;
+  }
+  if (params.sent === 0) {
+    return "failed" as const;
+  }
+  if (params.failed > 0 || params.sent < params.targeted) {
+    return "partial_failed" as const;
+  }
+  return "sent" as const;
+}
+
+export async function sendEventRewardWinnerNotifications(drawId: string) {
+  const supabase = getSupabaseAdminClient();
+  const { data: drawRow, error: drawError } = await supabase
+    .from("event_reward_draws")
+    .select(
+      "id,event_slug,status,seed,winner_count,candidate_count,total_tickets,google_form_url,guide_path,sent_notification_id,metadata,created_by_admin_id,created_at,finalized_at,sent_at,updated_at",
+    )
+    .eq("id", drawId)
+    .maybeSingle();
+  if (drawError) {
+    throw new Error(drawError.message);
+  }
+  if (!drawRow) {
+    throw new Error("추첨 결과를 찾을 수 없습니다.");
+  }
+  if (drawRow.sent_at) {
+    throw new Error("이미 당첨 안내를 발송했습니다.");
+  }
+
+  const { data: winnerRows, error: winnerError } = await supabase
+    .from("event_reward_winners")
+    .select(
+      "id,draw_id,event_slug,member_id,winner_rank,ticket_count,display_name,mm_username,year,campus,notification_status,notification_sent_at,notification_error,created_at,updated_at",
+    )
+    .eq("draw_id", drawId)
+    .order("winner_rank", { ascending: true });
+  if (winnerError) {
+    throw new Error(winnerError.message);
+  }
+
+  const winners = (winnerRows ?? []) as EventRewardWinnerRow[];
+  const memberIds = winners.map((winner) => winner.member_id);
+  if (memberIds.length === 0) {
+    throw new Error("당첨자가 없습니다.");
+  }
+
+  const result = await sendAdminNotificationCampaign({
+    notificationType: "announcement",
+    title: "싸트너십 추첨권 이벤트 당첨 안내",
+    body: "축하합니다. 기프티콘 발송 정보 입력을 위해 당첨 안내 페이지에서 구글폼을 확인해 주세요.",
+    url: drawRow.guide_path,
+    audience: {
+      scope: "member",
+      memberIds,
+    },
+    channels: {
+      in_app: true,
+      push: true,
+      mm: true,
+    },
+    confirmationText: "알림 발송",
+  });
+
+  const aggregate = Object.values(result.channelResults).reduce(
+    (accumulator, channel) => ({
+      targeted: accumulator.targeted + channel.targeted,
+      sent: accumulator.sent + channel.sent,
+      failed: accumulator.failed + channel.failed,
+    }),
+    { targeted: 0, sent: 0, failed: 0 },
+  );
+  const status = drawNotificationStatus(aggregate);
+  const sentAt = new Date().toISOString();
+  const errorMessage = result.warnings.length > 0 ? result.warnings.join("\n") : null;
+
+  const { error: updateDrawError } = await supabase
+    .from("event_reward_draws")
+    .update({
+      status,
+      sent_notification_id: result.notificationId,
+      sent_at: sentAt,
+      metadata: {
+        ...(drawRow.metadata ?? {}),
+        channelResults: result.channelResults,
+        warnings: result.warnings,
+      },
+    })
+    .eq("id", drawId);
+  if (updateDrawError) {
+    throw new Error(updateDrawError.message);
+  }
+
+  const { error: updateWinnerError } = await supabase
+    .from("event_reward_winners")
+    .update({
+      notification_status: status,
+      notification_sent_at: sentAt,
+      notification_error: errorMessage,
+    })
+    .eq("draw_id", drawId);
+  if (updateWinnerError) {
+    throw new Error(updateWinnerError.message);
+  }
+
+  return {
+    status,
+    notificationId: result.notificationId,
+    channelResults: result.channelResults,
+    warnings: result.warnings,
+  };
+}
+
+export async function getEventRewardWinnerGuide(params: {
+  eventSlug: string;
+  memberId: string;
+}) {
+  const supabase = getSupabaseAdminClient();
+  const { data: winner, error: winnerError } = await supabase
+    .from("event_reward_winners")
+    .select("draw_id,member_id,winner_rank,ticket_count")
+    .eq("event_slug", params.eventSlug)
+    .eq("member_id", params.memberId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (winnerError) {
+    throw new Error(winnerError.message);
+  }
+  if (!winner) {
+    return null;
+  }
+
+  const { data: draw, error: drawError } = await supabase
+    .from("event_reward_draws")
+    .select("id,event_slug,status,google_form_url,guide_path,sent_at")
+    .eq("id", winner.draw_id)
+    .maybeSingle();
+  if (drawError) {
+    throw new Error(drawError.message);
+  }
+  if (!draw) {
+    return null;
+  }
+
+  return {
+    eventSlug: draw.event_slug as string,
+    drawId: draw.id as string,
+    status: draw.status as EventRewardDrawRow["status"],
+    googleFormUrl: draw.google_form_url as string,
+    guidePath: draw.guide_path as string,
+    sentAt: draw.sent_at as string | null,
+    rank: winner.winner_rank as number,
+    ticketCount: winner.ticket_count as number,
+  };
 }

--- a/src/lib/promotions/events.ts
+++ b/src/lib/promotions/events.ts
@@ -46,6 +46,7 @@ type PromotionSlideRow = {
   is_active: boolean | null;
   audiences: unknown;
   allowed_campuses: unknown;
+  event_slug: string | null;
   created_at: string | null;
   updated_at: string | null;
 };
@@ -67,6 +68,7 @@ export type ManagedPromotionSlide = PromotionSlide & {
   isActive: boolean;
   audiences: PromotionAudience[];
   allowedCampuses: string[];
+  eventSlug: string | null;
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -143,6 +145,7 @@ function mapStaticSlide(slide: PromotionSlide, index: number): ManagedPromotionS
     isActive: true,
     audiences: normalizePromotionAudiences(slide.audiences),
     allowedCampuses: slide.allowedCampuses ?? [],
+    eventSlug: extractEventSlugFromHref(slide.href),
     createdAt: null,
     updatedAt: null,
   };
@@ -225,9 +228,15 @@ function mapSlideRow(row: PromotionSlideRow): ManagedPromotionSlide {
     isActive: row.is_active !== false,
     audiences: normalizePromotionAudiences(row.audiences),
     allowedCampuses: normalizeStringArray(row.allowed_campuses),
+    eventSlug: row.event_slug ?? extractEventSlugFromHref(row.href),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function extractEventSlugFromHref(href: string) {
+  const match = href.trim().match(/^\/events\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:[/?#]|$)/);
+  return match?.[1] ?? null;
 }
 
 function canUseSupabase() {
@@ -254,7 +263,7 @@ export async function listManagedPromotionSlides(options?: {
     let query = supabase
       .from("promotion_slides")
       .select(
-        "id,display_order,title,subtitle,image_src,image_alt,href,is_active,audiences,allowed_campuses,created_at,updated_at",
+        "id,display_order,title,subtitle,image_src,image_alt,href,is_active,audiences,allowed_campuses,event_slug,created_at,updated_at",
       )
       .order("display_order", { ascending: true })
       .order("created_at", { ascending: true });
@@ -279,6 +288,74 @@ export type PromotionSlideViewer = {
   year?: number | null;
   campus?: string | null;
 };
+
+export type PromotionCampaignStateKey =
+  | "unregistered"
+  | "inactive"
+  | "upcoming"
+  | "active"
+  | "expired";
+
+export type PromotionCampaignState = {
+  key: PromotionCampaignStateKey;
+  label: string;
+  isVisible: boolean;
+};
+
+function toTime(value: string) {
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+export function getPromotionCampaignState(
+  campaign: ManagedEventCampaign | null,
+  now: Date = new Date(),
+): PromotionCampaignState {
+  if (!campaign) {
+    return {
+      key: "unregistered",
+      label: "등록 필요",
+      isVisible: false,
+    };
+  }
+  if (!campaign.isActive) {
+    return {
+      key: "inactive",
+      label: "비활성",
+      isVisible: false,
+    };
+  }
+
+  const nowTime = now.getTime();
+  const startsAt = toTime(campaign.startsAt);
+  const endsAt = toTime(campaign.endsAt);
+  if (startsAt !== null && nowTime < startsAt) {
+    return {
+      key: "upcoming",
+      label: "진행 전",
+      isVisible: false,
+    };
+  }
+  if (endsAt !== null && nowTime > endsAt) {
+    return {
+      key: "expired",
+      label: "진행 후",
+      isVisible: false,
+    };
+  }
+  return {
+    key: "active",
+    label: "진행 중",
+    isVisible: true,
+  };
+}
+
+export function isPromotionCampaignVisible(
+  campaign: ManagedEventCampaign | null,
+  now: Date = new Date(),
+) {
+  return getPromotionCampaignState(campaign, now).isVisible;
+}
 
 export function canViewPromotionSlide(
   slide: ManagedPromotionSlide,
@@ -305,6 +382,21 @@ export function canViewPromotionSlide(
     }
   }
   return true;
+}
+
+export function canDisplayHomePromotionSlide(
+  slide: ManagedPromotionSlide,
+  viewer: PromotionSlideViewer,
+  campaignsBySlug: ReadonlyMap<string, ManagedEventCampaign>,
+  now: Date = new Date(),
+) {
+  if (!slide.isActive || !canViewPromotionSlide(slide, viewer)) {
+    return false;
+  }
+  if (!slide.eventSlug) {
+    return true;
+  }
+  return isPromotionCampaignVisible(campaignsBySlug.get(slide.eventSlug) ?? null, now);
 }
 
 export async function listManagedEventCampaigns(options?: {
@@ -347,9 +439,13 @@ export async function getManagedEventCampaign(slug: string) {
 export async function getHomePromotionSlides(
   viewer: PromotionSlideViewer = { authenticated: false, year: null, campus: null },
 ): Promise<PromotionSlide[]> {
-  const slides = await listManagedPromotionSlides({ includeInactive: false });
+  const [slides, campaigns] = await Promise.all([
+    listManagedPromotionSlides({ includeInactive: false }),
+    listManagedEventCampaigns({ includeInactive: true }),
+  ]);
+  const campaignsBySlug = new Map(campaigns.map((campaign) => [campaign.slug, campaign]));
   return slides
-    .filter((slide) => canViewPromotionSlide(slide, viewer))
+    .filter((slide) => canDisplayHomePromotionSlide(slide, viewer, campaignsBySlug))
     .map((slide) => ({
       id: slide.id,
       title: slide.title,

--- a/supabase/migrations/20260523162035_event_reward_ops.sql
+++ b/supabase/migrations/20260523162035_event_reward_ops.sql
@@ -1,0 +1,130 @@
+alter table public.promotion_slides
+  add column if not exists event_slug text references public.promotion_events(slug) on delete set null;
+
+update public.promotion_slides as slide
+set event_slug = event.slug
+from public.promotion_events as event
+where slide.event_slug is null
+  and (
+    slide.href = event.page_path
+    or slide.href = '/events/' || event.slug
+  );
+
+create index if not exists promotion_slides_event_slug_idx
+  on public.promotion_slides(event_slug);
+
+create table if not exists public.event_reward_draws (
+  id uuid primary key default uuid_generate_v4(),
+  event_slug text not null references public.promotion_events(slug) on delete cascade,
+  status text not null default 'draft',
+  seed text not null,
+  winner_count integer not null,
+  candidate_count integer not null default 0,
+  total_tickets integer not null default 0,
+  google_form_url text not null,
+  guide_path text not null,
+  sent_notification_id uuid references public.notifications(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by_admin_id text,
+  created_at timestamp with time zone not null default now(),
+  finalized_at timestamp with time zone,
+  sent_at timestamp with time zone,
+  updated_at timestamp with time zone not null default now(),
+  constraint event_reward_draws_status_check
+    check (status in ('draft', 'finalized', 'sent', 'partial_failed', 'failed')),
+  constraint event_reward_draws_winner_count_check
+    check (winner_count > 0),
+  constraint event_reward_draws_candidate_count_check
+    check (candidate_count >= 0),
+  constraint event_reward_draws_total_tickets_check
+    check (total_tickets >= 0),
+  constraint event_reward_draws_google_form_url_check
+    check (google_form_url like 'https://%'),
+  constraint event_reward_draws_guide_path_check
+    check (guide_path like '/%' and guide_path not like '//%')
+);
+
+comment on table public.event_reward_draws is
+  'Admin-created weighted reward event draws. One finalized draw is allowed per event.';
+
+create unique index if not exists event_reward_draws_one_finalized_per_event_idx
+  on public.event_reward_draws(event_slug)
+  where status in ('finalized', 'sent', 'partial_failed', 'failed');
+
+create index if not exists event_reward_draws_event_created_at_idx
+  on public.event_reward_draws(event_slug, created_at desc);
+
+create table if not exists public.event_reward_winners (
+  id uuid primary key default uuid_generate_v4(),
+  draw_id uuid not null references public.event_reward_draws(id) on delete cascade,
+  event_slug text not null references public.promotion_events(slug) on delete cascade,
+  member_id uuid not null references public.members(id) on delete cascade,
+  winner_rank integer not null,
+  ticket_count integer not null,
+  display_name text,
+  mm_username text,
+  year integer,
+  campus text,
+  notification_status text not null default 'pending',
+  notification_sent_at timestamp with time zone,
+  notification_error text,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint event_reward_winners_rank_check
+    check (winner_rank > 0),
+  constraint event_reward_winners_ticket_count_check
+    check (ticket_count > 0),
+  constraint event_reward_winners_notification_status_check
+    check (notification_status in ('pending', 'sent', 'partial_failed', 'failed', 'skipped')),
+  constraint event_reward_winners_draw_member_key unique (draw_id, member_id),
+  constraint event_reward_winners_draw_rank_key unique (draw_id, winner_rank)
+);
+
+comment on table public.event_reward_winners is
+  'Persisted winners for reward event draws and notification delivery status.';
+
+create index if not exists event_reward_winners_event_member_idx
+  on public.event_reward_winners(event_slug, member_id);
+
+create index if not exists event_reward_winners_draw_rank_idx
+  on public.event_reward_winners(draw_id, winner_rank);
+
+create or replace function public.set_event_reward_draws_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists event_reward_draws_set_updated_at on public.event_reward_draws;
+create trigger event_reward_draws_set_updated_at
+before update on public.event_reward_draws
+for each row
+execute function public.set_event_reward_draws_updated_at();
+
+create or replace function public.set_event_reward_winners_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists event_reward_winners_set_updated_at on public.event_reward_winners;
+create trigger event_reward_winners_set_updated_at
+before update on public.event_reward_winners
+for each row
+execute function public.set_event_reward_winners_updated_at();
+
+alter table public.event_reward_draws enable row level security;
+alter table public.event_reward_winners enable row level security;
+
+revoke all on table public.event_reward_draws from anon;
+revoke all on table public.event_reward_draws from authenticated;
+revoke all on table public.event_reward_winners from anon;
+revoke all on table public.event_reward_winners from authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2167,6 +2167,171 @@ create index if not exists partner_review_reactions_member_id_idx
 
 drop index if exists mm_verification_codes_email_idx;
 
+create table if not exists promotion_events (
+  id uuid primary key default uuid_generate_v4(),
+  slug text not null unique,
+  page_path text not null default '',
+  target_audiences text[] not null default array['guest', 'student', 'graduate', 'staff']::text[],
+  title text not null,
+  short_title text not null,
+  description text not null,
+  period_label text not null,
+  starts_at timestamp with time zone not null,
+  ends_at timestamp with time zone not null,
+  hero_image_src text not null,
+  hero_image_alt text not null,
+  conditions jsonb not null default '[]'::jsonb,
+  rules jsonb not null default '[]'::jsonb,
+  is_active boolean not null default true,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint promotion_events_slug_format_check
+    check (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+  constraint promotion_events_period_check
+    check (starts_at <= ends_at),
+  constraint promotion_events_conditions_array_check
+    check (jsonb_typeof(conditions) = 'array'),
+  constraint promotion_events_rules_array_check
+    check (jsonb_typeof(rules) = 'array')
+);
+
+comment on table promotion_events is
+  'Admin-managed public event landing pages and home promotion carousel event entries.';
+
+create index if not exists promotion_events_active_period_idx
+  on promotion_events(is_active, starts_at desc, ends_at desc);
+create index if not exists promotion_events_updated_at_idx
+  on promotion_events(updated_at desc);
+
+create table if not exists promotion_slides (
+  id uuid primary key default uuid_generate_v4(),
+  display_order integer not null,
+  title text not null,
+  subtitle text not null,
+  image_src text not null,
+  image_alt text not null,
+  href text not null,
+  is_active boolean not null default true,
+  requires_login boolean not null default false,
+  allowed_years integer[] not null default '{}'::integer[],
+  allowed_campuses text[] not null default '{}'::text[],
+  audiences text[] not null default array['guest', 'student', 'graduate', 'staff']::text[],
+  event_slug text references promotion_events(slug) on delete set null,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
+);
+
+create index if not exists promotion_slides_active_order_idx
+  on promotion_slides(is_active, display_order, created_at);
+create index if not exists promotion_slides_event_slug_idx
+  on promotion_slides(event_slug);
+
+create table if not exists event_reward_draws (
+  id uuid primary key default uuid_generate_v4(),
+  event_slug text not null references promotion_events(slug) on delete cascade,
+  status text not null default 'draft',
+  seed text not null,
+  winner_count integer not null,
+  candidate_count integer not null default 0,
+  total_tickets integer not null default 0,
+  google_form_url text not null,
+  guide_path text not null,
+  sent_notification_id uuid references notifications(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by_admin_id text,
+  created_at timestamp with time zone not null default now(),
+  finalized_at timestamp with time zone,
+  sent_at timestamp with time zone,
+  updated_at timestamp with time zone not null default now(),
+  constraint event_reward_draws_status_check
+    check (status in ('draft', 'finalized', 'sent', 'partial_failed', 'failed')),
+  constraint event_reward_draws_winner_count_check
+    check (winner_count > 0),
+  constraint event_reward_draws_candidate_count_check
+    check (candidate_count >= 0),
+  constraint event_reward_draws_total_tickets_check
+    check (total_tickets >= 0),
+  constraint event_reward_draws_google_form_url_check
+    check (google_form_url like 'https://%'),
+  constraint event_reward_draws_guide_path_check
+    check (guide_path like '/%' and guide_path not like '//%')
+);
+
+comment on table event_reward_draws is
+  'Admin-created weighted reward event draws. One finalized draw is allowed per event.';
+
+create unique index if not exists event_reward_draws_one_finalized_per_event_idx
+  on event_reward_draws(event_slug)
+  where status in ('finalized', 'sent', 'partial_failed', 'failed');
+create index if not exists event_reward_draws_event_created_at_idx
+  on event_reward_draws(event_slug, created_at desc);
+
+create table if not exists event_reward_winners (
+  id uuid primary key default uuid_generate_v4(),
+  draw_id uuid not null references event_reward_draws(id) on delete cascade,
+  event_slug text not null references promotion_events(slug) on delete cascade,
+  member_id uuid not null references members(id) on delete cascade,
+  winner_rank integer not null,
+  ticket_count integer not null,
+  display_name text,
+  mm_username text,
+  year integer,
+  campus text,
+  notification_status text not null default 'pending',
+  notification_sent_at timestamp with time zone,
+  notification_error text,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint event_reward_winners_rank_check
+    check (winner_rank > 0),
+  constraint event_reward_winners_ticket_count_check
+    check (ticket_count > 0),
+  constraint event_reward_winners_notification_status_check
+    check (notification_status in ('pending', 'sent', 'partial_failed', 'failed', 'skipped')),
+  constraint event_reward_winners_draw_member_key unique (draw_id, member_id),
+  constraint event_reward_winners_draw_rank_key unique (draw_id, winner_rank)
+);
+
+comment on table event_reward_winners is
+  'Persisted winners for reward event draws and notification delivery status.';
+
+create index if not exists event_reward_winners_event_member_idx
+  on event_reward_winners(event_slug, member_id);
+create index if not exists event_reward_winners_draw_rank_idx
+  on event_reward_winners(draw_id, winner_rank);
+
+create or replace function set_event_reward_draws_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists event_reward_draws_set_updated_at on event_reward_draws;
+create trigger event_reward_draws_set_updated_at
+  before update on event_reward_draws
+  for each row
+  execute function set_event_reward_draws_updated_at();
+
+create or replace function set_event_reward_winners_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists event_reward_winners_set_updated_at on event_reward_winners;
+create trigger event_reward_winners_set_updated_at
+  before update on event_reward_winners
+  for each row
+  execute function set_event_reward_winners_updated_at();
+
 alter table categories enable row level security;
 alter table public_cache_versions enable row level security;
 alter table partner_companies enable row level security;
@@ -2198,6 +2363,10 @@ alter table push_delivery_logs enable row level security;
 alter table event_logs enable row level security;
 alter table partner_metric_rollups enable row level security;
 alter table partner_metric_unique_visitors enable row level security;
+alter table promotion_events enable row level security;
+alter table promotion_slides enable row level security;
+alter table event_reward_draws enable row level security;
+alter table event_reward_winners enable row level security;
 alter table admin_audit_logs enable row level security;
 alter table auth_security_logs enable row level security;
 
@@ -2270,6 +2439,14 @@ revoke all on table partner_metric_rollups from anon;
 revoke all on table partner_metric_rollups from authenticated;
 revoke all on table partner_metric_unique_visitors from anon;
 revoke all on table partner_metric_unique_visitors from authenticated;
+revoke all on table promotion_events from anon;
+revoke all on table promotion_events from authenticated;
+revoke all on table promotion_slides from anon;
+revoke all on table promotion_slides from authenticated;
+revoke all on table event_reward_draws from anon;
+revoke all on table event_reward_draws from authenticated;
+revoke all on table event_reward_winners from anon;
+revoke all on table event_reward_winners from authenticated;
 revoke all on table admin_audit_logs from anon;
 revoke all on table admin_audit_logs from authenticated;
 revoke all on table auth_security_logs from anon;

--- a/tests/event-reward-admin.test.mts
+++ b/tests/event-reward-admin.test.mts
@@ -134,3 +134,173 @@ test("event reward csv export uses the same row values as admin overview", async
   assert.match(csv, /이름,MM ID,기수,캠퍼스,총 추첨권/);
   assert.match(csv, /"김,싸피",kim,15,서울,5,완료,미완료,완료,완료,1/);
 });
+
+test("event reward comparison csv marks unrecoverable before states as unknown", async () => {
+  const {
+    buildEventRewardComparisonOverview,
+    createEventRewardComparisonCsv,
+  } = await eventRewardsModulePromise;
+
+  const overview = buildEventRewardComparisonOverview(campaign, [
+    {
+      id: "member-1",
+      displayName: "김싸피",
+      mmUsername: "kim",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: true,
+        marketingEnabled: true,
+      },
+      reviewCount: 1,
+    },
+    {
+      id: "member-2",
+      displayName: "이싸피",
+      mmUsername: "lee",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-05-01T00:00:00+09:00",
+      preferences: {
+        enabled: false,
+        mmEnabled: false,
+        marketingEnabled: false,
+      },
+      reviewCount: 0,
+    },
+  ]);
+  const csv = createEventRewardComparisonCsv(overview);
+
+  assert.equal(overview.members[0]?.existedBeforeEvent, true);
+  assert.equal(overview.members[1]?.joinedDuringEvent, true);
+  assert.match(csv, /Before 추첨권\(확인가능\),After 추첨권,증감\(확인가능\)/);
+  assert.match(csv, /확인불가/);
+  assert.match(csv, /김싸피,kim,15,서울,Y,N,1,6,5,완료,확인불가,확인불가,확인불가,완료,완료,완료,완료,1/);
+});
+
+test("event reward weighted draw is deterministic and excludes zero-ticket members", async () => {
+  const {
+    buildEventRewardAdminOverview,
+    createEventRewardDrawPlan,
+  } = await eventRewardsModulePromise;
+  const overview = buildEventRewardAdminOverview(campaign, [
+    {
+      id: "member-zero",
+      displayName: "무응모",
+      mmUsername: "zero",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-05-13T00:00:00+09:00",
+      preferences: null,
+      reviewCount: 0,
+    },
+    {
+      id: "member-one",
+      displayName: "한장",
+      mmUsername: "one",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: null,
+      reviewCount: 0,
+    },
+    {
+      id: "member-five",
+      displayName: "다섯장",
+      mmUsername: "five",
+      year: 15,
+      campus: "서울",
+      createdAt: "2026-04-01T00:00:00+09:00",
+      preferences: {
+        enabled: true,
+        mmEnabled: true,
+        marketingEnabled: true,
+      },
+      reviewCount: 1,
+    },
+  ]);
+
+  const first = createEventRewardDrawPlan(overview, {
+    winnerCount: 2,
+    seed: "stable-seed",
+  });
+  const second = createEventRewardDrawPlan(overview, {
+    winnerCount: 2,
+    seed: "stable-seed",
+  });
+
+  assert.deepEqual(
+    first.winners.map((winner) => winner.memberId),
+    second.winners.map((winner) => winner.memberId),
+  );
+  assert.equal(first.candidateCount, 2);
+  assert.equal(first.totalTickets, 7);
+  assert.equal(new Set(first.winners.map((winner) => winner.memberId)).size, 2);
+  assert.equal(
+    first.winners.some((winner) => winner.memberId === "member-zero"),
+    false,
+  );
+});
+
+test("event reward draw input validates winner count and Google Forms URL", async () => {
+  const {
+    normalizeEventRewardDrawRequest,
+  } = await eventRewardsModulePromise;
+
+  assert.throws(
+    () =>
+      normalizeEventRewardDrawRequest({
+        winnerCount: 0,
+        googleFormUrl: "https://forms.gle/example",
+      }),
+    /당첨 인원/,
+  );
+  assert.throws(
+    () =>
+      normalizeEventRewardDrawRequest({
+        winnerCount: 1,
+        googleFormUrl: "https://example.com/form",
+      }),
+    /구글폼/,
+  );
+  assert.deepEqual(
+    normalizeEventRewardDrawRequest({
+      winnerCount: 1,
+      seed: " seed ",
+      googleFormUrl: "https://docs.google.com/forms/d/e/abc/viewform",
+    }),
+    {
+      winnerCount: 1,
+      seed: "seed",
+      googleFormUrl: "https://docs.google.com/forms/d/e/abc/viewform",
+    },
+  );
+});
+
+test("winner form access only allows the winning signed-in member", async () => {
+  const { canViewEventRewardWinnerForm } = await eventRewardsModulePromise;
+
+  assert.equal(
+    canViewEventRewardWinnerForm({
+      memberId: null,
+      winnerMemberIds: ["member-1"],
+    }),
+    false,
+  );
+  assert.equal(
+    canViewEventRewardWinnerForm({
+      memberId: "member-2",
+      winnerMemberIds: ["member-1"],
+    }),
+    false,
+  );
+  assert.equal(
+    canViewEventRewardWinnerForm({
+      memberId: "member-1",
+      winnerMemberIds: ["member-1"],
+    }),
+    true,
+  );
+});

--- a/tests/promotion-visibility.test.mts
+++ b/tests/promotion-visibility.test.mts
@@ -16,6 +16,7 @@ const promotionsPromise = import(
 function createSlide(options: {
   audiences: PromotionAudience[];
   allowedCampuses?: string[];
+  eventSlug?: string | null;
 }): ManagedPromotionSlide {
   return {
     id: "guest-visible-ad",
@@ -30,6 +31,34 @@ function createSlide(options: {
     isActive: true,
     audiences: options.audiences,
     allowedCampuses: options.allowedCampuses ?? [],
+    eventSlug: options.eventSlug ?? null,
+    createdAt: "2026-04-27T00:00:00.000Z",
+    updatedAt: "2026-04-27T00:00:00.000Z",
+  };
+}
+
+function createCampaign(options: {
+  isActive?: boolean;
+  startsAt?: string;
+  endsAt?: string;
+}) {
+  return {
+    id: "event-1",
+    slug: "signup-reward",
+    title: "싸트너십 추첨권 이벤트",
+    shortTitle: "추첨권 이벤트",
+    description: "이벤트",
+    periodLabel: "기간",
+    startsAt: options.startsAt ?? "2026-05-01T00:00:00+09:00",
+    endsAt: options.endsAt ?? "2026-05-31T23:59:59+09:00",
+    heroImageSrc: "/ads/reward-event.svg",
+    heroImageAlt: "이벤트",
+    conditions: [],
+    rules: [],
+    pagePath: "/events/signup-reward",
+    targetAudiences: ["guest", "student", "graduate", "staff"] as PromotionAudience[],
+    isActive: options.isActive ?? true,
+    source: "database" as const,
     createdAt: "2026-04-27T00:00:00.000Z",
     updatedAt: "2026-04-27T00:00:00.000Z",
   };
@@ -79,4 +108,90 @@ test("promotion slide visibility still respects audience and campus for authenti
   assert.equal(canViewPromotionSlide(slide, seoulStudent), true);
   assert.equal(canViewPromotionSlide(slide, daejeonStudent), false);
   assert.equal(canViewPromotionSlide(slide, guest), false);
+});
+
+test("promotion campaign visibility follows active flag and period", async () => {
+  const { getPromotionCampaignState, isPromotionCampaignVisible } =
+    await promotionsPromise;
+  const now = new Date("2026-05-10T12:00:00+09:00");
+  const expiredCatalogCampaign = {
+    ...createCampaign({
+      endsAt: "2026-05-09T23:59:59+09:00",
+    }),
+    id: null,
+    source: "catalog" as const,
+  };
+
+  assert.equal(getPromotionCampaignState(null, now).key, "unregistered");
+  assert.equal(
+    getPromotionCampaignState(createCampaign({ isActive: false }), now).key,
+    "inactive",
+  );
+  assert.equal(
+    getPromotionCampaignState(
+      createCampaign({ startsAt: "2026-05-20T00:00:00+09:00" }),
+      now,
+    ).key,
+    "upcoming",
+  );
+  assert.equal(getPromotionCampaignState(createCampaign({}), now).key, "active");
+  assert.equal(
+    getPromotionCampaignState(
+      createCampaign({ endsAt: "2026-05-09T23:59:59+09:00" }),
+      now,
+    ).key,
+    "expired",
+  );
+  assert.equal(isPromotionCampaignVisible(createCampaign({}), now), true);
+  assert.equal(
+    isPromotionCampaignVisible(
+      createCampaign({ endsAt: "2026-05-09T23:59:59+09:00" }),
+      now,
+    ),
+    false,
+  );
+  assert.equal(getPromotionCampaignState(expiredCatalogCampaign, now).key, "expired");
+  assert.equal(isPromotionCampaignVisible(expiredCatalogCampaign, now), false);
+});
+
+test("linked home carousel slides are hidden when the event is no longer visible", async () => {
+  const { canDisplayHomePromotionSlide } = await promotionsPromise;
+  const viewer = {
+    authenticated: false,
+    year: null,
+    campus: null,
+  };
+  const linkedSlide = createSlide({
+    audiences: ["guest"],
+    eventSlug: "signup-reward",
+  });
+  const unlinkedSlide = createSlide({
+    audiences: ["guest"],
+    eventSlug: null,
+  });
+  const campaigns = new Map([
+    [
+      "signup-reward",
+      createCampaign({ endsAt: "2026-05-09T23:59:59+09:00" }),
+    ],
+  ]);
+
+  assert.equal(
+    canDisplayHomePromotionSlide(
+      linkedSlide,
+      viewer,
+      campaigns,
+      new Date("2026-05-10T12:00:00+09:00"),
+    ),
+    false,
+  );
+  assert.equal(
+    canDisplayHomePromotionSlide(
+      unlinkedSlide,
+      viewer,
+      campaigns,
+      new Date("2026-05-10T12:00:00+09:00"),
+    ),
+    true,
+  );
 });

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/rss",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/archive-expired-promotions",
+      "schedule": "5 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `dev`에 병합된 이벤트 종료/추첨권 운영 기능을 `main`으로 승격합니다.
- 현재 `dev`에는 PR #36과 직전 hotfix 병합분이 포함되어 있습니다.

## Related Issue
Closes #35

## Branch Flow
dev -> main

## Changes
- 종료 이벤트/public route/home carousel visibility 연동
- 이벤트 archive cron 및 Supabase reward draw/winner 테이블 추가
- signup-reward 관리자 성과 비교 CSV, 가중 추첨, 당첨자 안내 발송 흐름 추가
- 다크모드 active 인터랙션 스타일 정리

## Test Plan
- [x] `npm run release` on `feat/event-reward-ops`
- [x] `npm run build-storybook`
- [x] `npm run test-storybook`
- [x] PR #36 Supabase Preview 통과
- [x] PR #36 Vercel Preview 통과
- [x] PR #36 lockfile checks 통과
- [ ] Chromatic UI Tests는 4개 baseline 승인 대기
- [ ] `npx tsc --noEmit --pretty false`는 기존 테스트 타입 오류로 실패

## Checklist
- [x] `dev` 병합 완료
- [x] Production 대상 `main` 승격 PR
