### PR TITLE
fix: Preview Supabase 비활성 시 자동 동기화 건너뛰기

### DIFF
--- a/.github/workflows/preview-sync.yml
+++ b/.github/workflows/preview-sync.yml
@@ -39,6 +39,7 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_PREVIEW_SERVICE_ROLE_KEY }}
       PREVIEW_TEST_MEMBER_USERNAME: ${{ secrets.PREVIEW_TEST_MEMBER_USERNAME }}
       PREVIEW_TEST_MEMBER_PASSWORD: ${{ secrets.PREVIEW_TEST_MEMBER_PASSWORD }}
+      SUPABASE_PREVIEW_SYNC_SKIP_UNAVAILABLE: ${{ github.event_name == 'workflow_run' && 'true' || 'false' }}
     steps:
       - name: Checkout workflow run commit
         if: github.event_name == 'workflow_run'
@@ -73,7 +74,9 @@ jobs:
           version: latest
 
       - name: Sync production data and storage to preview
+        id: sync-preview-data
         run: npm run sync:preview
 
       - name: Apply preview migrations
+        if: steps.sync-preview-data.outputs.preview_database_available != 'false'
         run: supabase db push --db-url "$SUPABASE_PREVIEW_DB_URL" --yes --include-all

--- a/scripts/supabase-db-health-lib.mjs
+++ b/scripts/supabase-db-health-lib.mjs
@@ -1,0 +1,9 @@
+export function isMissingSupabasePoolerTenantErrorMessage(message) {
+  const normalized = String(message ?? "").toLowerCase();
+
+  return (
+    normalized.includes("tenant/user") &&
+    normalized.includes("not found") &&
+    normalized.includes("enotfound")
+  );
+}

--- a/scripts/supabase-sync-preview.mjs
+++ b/scripts/supabase-sync-preview.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
@@ -9,6 +9,7 @@ import {
   formatStorageError,
   runStorageOperation,
 } from "./supabase-sync-preview-storage.mjs";
+import { isMissingSupabasePoolerTenantErrorMessage } from "./supabase-db-health-lib.mjs";
 import {
   hashPreviewSeedPassword,
   isValidPreviewSeedPassword,
@@ -41,6 +42,21 @@ function requiredEnv(name) {
     throw new Error(`${name} 환경 변수가 필요합니다.`);
   }
   return value;
+}
+
+function isTruthyEnv(name) {
+  return ["1", "true", "yes", "on"].includes(
+    (process.env[name] ?? "").trim().toLowerCase(),
+  );
+}
+
+async function writeGithubOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  await appendFile(outputPath, `${name}=${value}\n`, "utf8");
 }
 
 function quoteIdentifier(identifier) {
@@ -194,6 +210,26 @@ async function dumpProductionDatabase(dumpPath, productionDbUrl) {
 
   console.log("Syncing production public data dump...");
   await runCommand("supabase", args);
+}
+
+async function assertPreviewDatabaseAvailable(previewDbUrl) {
+  await runCommand(
+    "psql",
+    [
+      "--dbname",
+      previewDbUrl,
+      "--tuples-only",
+      "--no-align",
+      "--command",
+      "select 1;",
+    ],
+    {
+      captureStdout: true,
+      env: {
+        PGCONNECT_TIMEOUT: "10",
+      },
+    },
+  );
 }
 
 async function sanitizeDumpForPreview(dumpPath, previewDbUrl) {
@@ -619,6 +655,30 @@ async function main() {
   const previewDbUrl = requiredEnv("SUPABASE_PREVIEW_DB_URL");
   const previewUrl = requiredEnv("SUPABASE_PREVIEW_URL");
   const previewServiceRoleKey = requiredEnv("SUPABASE_PREVIEW_SERVICE_ROLE_KEY");
+  const skipUnavailablePreview = isTruthyEnv("SUPABASE_PREVIEW_SYNC_SKIP_UNAVAILABLE");
+
+  try {
+    await assertPreviewDatabaseAvailable(previewDbUrl);
+    await writeGithubOutput("preview_database_available", "true");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      skipUnavailablePreview &&
+      isMissingSupabasePoolerTenantErrorMessage(message)
+    ) {
+      console.warn(
+        [
+          "Skipping preview sync because the Supabase Preview database is unavailable.",
+          "The pooler returned a missing tenant/user error; update SUPABASE_PREVIEW_DB_URL",
+          "or recreate the Preview Supabase database before running a manual sync.",
+        ].join(" "),
+      );
+      await writeGithubOutput("preview_database_available", "false");
+      return;
+    }
+
+    throw error;
+  }
 
   const tempDir = await mkdtemp(join(tmpdir(), "ssartnership-preview-sync-"));
   const dumpPath = join(tempDir, "production-data.sql");

--- a/tests/preview-db-health.test.mts
+++ b/tests/preview-db-health.test.mts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isMissingSupabasePoolerTenantErrorMessage } from "../scripts/supabase-db-health-lib.mjs";
+
+test("preview db health detects missing Supabase pooler tenant errors", () => {
+  assert.equal(
+    isMissingSupabasePoolerTenantErrorMessage(
+      'psql: error: connection to server at "aws-1-ap-northeast-2.pooler.supabase.com", port 5432 failed: FATAL:  (ENOTFOUND) tenant/user postgres.uuxzzanpxzvhauzxufuk not found',
+    ),
+    true,
+  );
+  assert.equal(
+    isMissingSupabasePoolerTenantErrorMessage(
+      "psql: error: FATAL: password authentication failed for user postgres",
+    ),
+    false,
+  );
+  assert.equal(
+    isMissingSupabasePoolerTenantErrorMessage(
+      "psql: error: connection timeout expired",
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- Preview Supabase DB 연결을 production dump 전에 preflight로 확인합니다.
- 자동 workflow_run에서는 Supabase pooler의 missing tenant/user 오류를 warning으로 처리하고 sync/migration 단계를 건너뜁니다.
- manual dispatch나 다른 DB 오류는 기존처럼 실패시켜 잘못된 secret/password/schema 문제를 숨기지 않습니다.

## Root Cause
- GitHub Actions 실패는 앱 빌드 문제가 아니라 `SUPABASE_PREVIEW_DB_URL`이 가리키는 Supabase pooler tenant/user가 사라졌거나 secret이 stale해서 발생했습니다.
- 로그의 `FATAL: (ENOTFOUND) tenant/user postgres.uuxzzanpxzvhauzxufuk not found`가 해당 증거입니다.

## Test Plan
- node --import ./tests/alias-register.mjs --test tests/preview-db-health.test.mts tests/preview-sync-sanitize.test.mts tests/preview-credential-seed.test.mts
- npm run lint -- scripts/supabase-sync-preview.mjs scripts/supabase-db-health-lib.mjs tests/preview-db-health.test.mts
- npm run validate:migrations
- ruby YAML parse for .github/workflows/preview-sync.yml
- npm run release (Storybook build/test gates)