### PR TITLE
fix: Preview 동기화 전 마이그레이션 적용

### DIFF
--- a/.github/workflows/preview-sync.yml
+++ b/.github/workflows/preview-sync.yml
@@ -73,10 +73,19 @@ jobs:
         with:
           version: latest
 
+      - name: Check preview database connection
+        id: preview-db
+        run: node scripts/supabase-sync-preview.mjs --check-only
+
+      - name: Apply preview migrations before sync
+        if: steps.preview-db.outputs.preview_database_available != 'false'
+        run: supabase db push --db-url "$SUPABASE_PREVIEW_DB_URL" --yes --include-all
+
       - name: Sync production data and storage to preview
         id: sync-preview-data
+        if: steps.preview-db.outputs.preview_database_available != 'false'
         run: npm run sync:preview
 
-      - name: Apply preview migrations
-        if: steps.sync-preview-data.outputs.preview_database_available != 'false'
+      - name: Verify preview migrations after sync
+        if: steps.preview-db.outputs.preview_database_available != 'false'
         run: supabase db push --db-url "$SUPABASE_PREVIEW_DB_URL" --yes --include-all

--- a/scripts/supabase-sync-preview.mjs
+++ b/scripts/supabase-sync-preview.mjs
@@ -18,6 +18,7 @@ import {
 import { sanitizeDumpSqlForPreview } from "./supabase-sync-preview-lib.mjs";
 
 const PUBLIC_SCHEMA = "public";
+const CHECK_ONLY_FLAG = "--check-only";
 const DEFAULT_CACHE_CONTROL = "31536000";
 const EXCLUDED_PUBLIC_TABLES = [
   "admin_login_attempts",
@@ -649,6 +650,7 @@ async function syncStorageBuckets(productionUrl, productionServiceRoleKey, previ
 }
 
 async function main() {
+  const checkOnly = process.argv.includes(CHECK_ONLY_FLAG);
   const productionDbUrl = requiredEnv("SUPABASE_PRODUCTION_DB_URL");
   const productionUrl = requiredEnv("SUPABASE_PRODUCTION_URL");
   const productionServiceRoleKey = requiredEnv("SUPABASE_PRODUCTION_SERVICE_ROLE_KEY");
@@ -678,6 +680,11 @@ async function main() {
     }
 
     throw error;
+  }
+
+  if (checkOnly) {
+    console.log("Preview database connection preflight passed.");
+    return;
   }
 
   const tempDir = await mkdtemp(join(tmpdir(), "ssartnership-preview-sync-"));


### PR DESCRIPTION
## Summary
- Preview DB 연결 preflight를 별도 step으로 분리합니다.
- Production dump restore 전에 Preview migrations를 먼저 적용해 신규 테이블 COPY 실패를 막습니다.
- sync 후 migration 검증 step은 유지합니다.

## Root Cause
- Preview 서버 resume 후 DB 연결은 복구됐지만, Preview schema가 최신 migration을 적용받기 전에 Production dump를 restore했습니다.
- Production dump에 `event_reward_draws` COPY가 포함되어 있는데 Preview DB에는 아직 해당 테이블이 없어 실패했습니다.

## Branch Flow
- `hotfix/preview-sync-migration-order` -> `main`, 이후 `dev` ff-sync

## Changes
- `scripts/supabase-sync-preview.mjs`에 `--check-only` preflight 모드를 추가했습니다.
- `.github/workflows/preview-sync.yml`에서 Preview 연결 확인 후 migration push를 먼저 실행하고, 그 다음 data/storage sync를 수행하도록 순서를 조정했습니다.

## Test Plan
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/preview-sync.yml'); puts 'yaml-ok'"`\n- `node --import ./tests/alias-register.mjs --test tests/preview-db-health.test.mts tests/preview-sync-sanitize.test.mts tests/preview-credential-seed.test.mts`\n- `npm run lint -- scripts/supabase-sync-preview.mjs scripts/supabase-db-health-lib.mjs tests/preview-db-health.test.mts`\n- `npm run validate:migrations`\n- `npm run release` (Storybook build/test gates)\n\n## Checklist\n- [x] Root cause confirmed from GitHub Actions log\n- [x] Focused local verification passed\n- [x] Release script commit/push completed\n