### PR TITLE
feat: 이벤트 당첨 안내 운영 기능 배포

### DIFF
--- a/src/app/admin/(protected)/_actions/promotion-actions.ts
+++ b/src/app/admin/(protected)/_actions/promotion-actions.ts
@@ -12,6 +12,7 @@ import { getEventPageDefinition } from "@/lib/event-pages";
 import {
   createStoredEventRewardDraw,
   normalizeEventRewardDrawRequest,
+  sendEventRewardWinnerTestNotification,
   sendEventRewardWinnerNotifications,
 } from "@/lib/promotions/event-rewards";
 import { getManagedEventCampaign } from "@/lib/promotions/events";
@@ -473,7 +474,10 @@ export async function sendEventRewardWinnerNotificationsAction(formData: FormDat
   await requireAdmin();
   const slug = normalizeSlug(getRequiredString(formData, "slug"));
   const drawId = getRequiredString(formData, "drawId");
-  const result = await sendEventRewardWinnerNotifications(drawId);
+  const result = await sendEventRewardWinnerNotifications(drawId, {
+    eventSlug: slug,
+    confirmationText: getString(formData, "confirmationText"),
+  });
 
   await logAdminAction("event_reward_winner_notification_send", {
     targetType: "event_reward_draw",
@@ -487,4 +491,29 @@ export async function sendEventRewardWinnerNotificationsAction(formData: FormDat
   });
   revalidatePromotionPaths(slug);
   redirect(`/admin/event/${slug}?status=winner-sent`);
+}
+
+export async function sendEventRewardWinnerTestNotificationAction(formData: FormData) {
+  await requireAdmin();
+  const slug = normalizeSlug(getRequiredString(formData, "slug"));
+  const drawId = getRequiredString(formData, "drawId");
+  const memberId = getRequiredString(formData, "memberId");
+  const result = await sendEventRewardWinnerTestNotification(drawId, {
+    eventSlug: slug,
+    memberId,
+  });
+
+  await logAdminAction("event_reward_winner_notification_test_send", {
+    targetType: "event_reward_draw",
+    targetId: drawId,
+    properties: {
+      eventSlug: slug,
+      memberId,
+      status: result.status,
+      notificationId: result.notificationId,
+      warnings: result.warnings.length,
+    },
+  });
+  revalidatePromotionPaths(slug);
+  redirect(`/admin/event/${slug}?status=winner-test-sent`);
 }

--- a/src/app/admin/(protected)/event/[slug]/page.tsx
+++ b/src/app/admin/(protected)/event/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   createEventRewardDrawAction,
   createPromotionEventAction,
   deletePromotionEventAction,
+  sendEventRewardWinnerTestNotificationAction,
   sendEventRewardWinnerNotificationsAction,
   updatePromotionEventAction,
 } from "@/app/admin/(protected)/_actions/promotion-actions";
@@ -19,6 +20,7 @@ import { PROMOTION_AUDIENCE_OPTIONS, type EventCampaign } from "@/lib/promotions
 import {
   buildEventRewardAdminOverview,
   buildEventRewardComparisonOverview,
+  EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
   getEventRewardAdminOverview,
   getLatestEventRewardDrawWithWinners,
   type EventRewardAdminMemberRow,
@@ -48,6 +50,9 @@ function statusMessage(status?: string) {
   }
   if (status === "winner-sent") {
     return "당첨 안내를 발송했습니다.";
+  }
+  if (status === "winner-test-sent") {
+    return "당첨 안내 테스트를 발송했습니다.";
   }
   return null;
 }
@@ -126,6 +131,11 @@ function SignupRewardOverviewSection({
     { label: "푸시", value: `${overview.conditionCounts.push ?? 0}명` },
     { label: "마케팅", value: `${overview.conditionCounts.marketing ?? 0}명` },
   ];
+  const testRecipientOptions = overview.members.map((member) => ({
+    id: member.id,
+    label: `${member.displayName || member.mmUsername} (@${member.mmUsername})`,
+    meta: `${member.year}기 · ${member.campus || "-"} · ${member.totalTickets.toLocaleString()}장`,
+  }));
 
   return (
     <section className="grid gap-5" aria-label="추첨권 현황">
@@ -232,13 +242,81 @@ function SignupRewardOverviewSection({
                 </tbody>
               </table>
             </div>
-            {!draw.sentAt ? (
-              <form action={sendEventRewardWinnerNotificationsAction} className="flex justify-end">
+            <div className="grid gap-3 lg:grid-cols-2">
+              <form
+                action={sendEventRewardWinnerTestNotificationAction}
+                className="grid gap-3 rounded-[1rem] border border-border/70 bg-surface-inset p-4"
+              >
                 <input type="hidden" name="slug" value="signup-reward" />
                 <input type="hidden" name="drawId" value={draw.id} />
-                <Button type="submit">앱+MM+푸시 발송</Button>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">테스트 발송</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    앱+MM+푸시 채널로 테스트 안내를 보냅니다.
+                  </p>
+                </div>
+                <label className="grid gap-2 text-sm font-medium text-foreground">
+                  수신자
+                  <select
+                    name="memberId"
+                    required
+                    defaultValue=""
+                    className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground"
+                  >
+                    <option value="" disabled>
+                      테스트 수신자 선택
+                    </option>
+                    {testRecipientOptions.map((member) => (
+                      <option key={member.id} value={member.id}>
+                        {member.label} · {member.meta}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div className="flex justify-end">
+                  <Button type="submit" variant="secondary">
+                    테스트 발송
+                  </Button>
+                </div>
               </form>
-            ) : null}
+
+              {!draw.sentAt ? (
+                <form
+                  action={sendEventRewardWinnerNotificationsAction}
+                  className="grid gap-3 rounded-[1rem] border border-primary/20 bg-primary-soft p-4"
+                >
+                  <input type="hidden" name="slug" value="signup-reward" />
+                  <input type="hidden" name="drawId" value={draw.id} />
+                  <div>
+                    <p className="text-sm font-semibold text-primary">실제 발송</p>
+                    <p className="mt-1 text-xs text-primary/80">
+                      당첨자 {draw.winners.length.toLocaleString()}명에게 앱+MM+푸시 안내를 보냅니다.
+                    </p>
+                  </div>
+                  <label className="grid gap-2 text-sm font-medium text-primary">
+                    확인 문구
+                    <input
+                      name="confirmationText"
+                      required
+                      pattern={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                      placeholder={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                      title={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                      className="h-11 rounded-input border border-primary/20 bg-surface-control px-3 text-sm text-foreground"
+                    />
+                  </label>
+                  <div className="flex justify-end">
+                    <Button type="submit">발송 확인</Button>
+                  </div>
+                </form>
+              ) : (
+                <div className="rounded-[1rem] border border-border/70 bg-surface-inset p-4">
+                  <p className="text-sm font-semibold text-foreground">발송 완료</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {formatEventDate(draw.sentAt)}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         ) : (
           <form action={createEventRewardDrawAction} className="grid gap-4">

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -74,6 +74,7 @@ export const ADMIN_AUDIT_ACTIONS = [
   'promotion_slide_delete',
   'promotion_slide_bulk_update',
   'event_reward_draw_create',
+  'event_reward_winner_notification_test_send',
   'event_reward_winner_notification_send',
 ] as const;
 

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -4,7 +4,10 @@ import { fetchMemberVisibleReviewCountInRange } from "@/lib/partner-counts";
 import { collectPagedRows } from "@/lib/log-insights/paging";
 import { getPolicyDocumentByKind } from "@/lib/policy-documents";
 import { getPushPreferencesOrDefault } from "@/lib/push";
-import { sendAdminNotificationCampaign } from "@/lib/admin-notification-ops";
+import {
+  sendAdminNotificationCampaign,
+  type AdminNotificationComposerInput,
+} from "@/lib/admin-notification-ops";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import type { EventCampaign, EventConditionKey } from "@/lib/promotions/catalog";
 
@@ -204,6 +207,8 @@ export type EventRewardStoredDraw = {
 };
 
 export type EventRewardNotificationSendStatus = "sent" | "partial_failed" | "failed";
+
+export const EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT = "알림 발송";
 
 function assertEventRewardQuerySucceeded(error: unknown, label: string) {
   if (!error) {
@@ -577,6 +582,29 @@ export function normalizeEventRewardDrawRequest(input: {
   };
 }
 
+export function normalizeEventRewardWinnerNotificationRequest(input: {
+  confirmationText?: unknown;
+}) {
+  const confirmationText =
+    typeof input.confirmationText === "string" ? input.confirmationText.trim() : "";
+  if (confirmationText !== EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT) {
+    throw new Error(
+      `확인 문구 '${EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}'를 정확히 입력해 주세요.`,
+    );
+  }
+  return { confirmationText };
+}
+
+export function normalizeEventRewardTestNotificationRequest(input: {
+  memberId?: unknown;
+}) {
+  const memberId = typeof input.memberId === "string" ? input.memberId.trim() : "";
+  if (!memberId) {
+    throw new Error("테스트 수신자를 선택해 주세요.");
+  }
+  return { memberId };
+}
+
 export function createEventRewardDrawPlan(
   overview: EventRewardAdminOverview,
   input: {
@@ -942,21 +970,77 @@ export function isEventRewardNotificationSendComplete(
   return status === "sent" && Boolean(sentAt);
 }
 
-export async function sendEventRewardWinnerNotifications(drawId: string) {
+export function buildEventRewardWinnerNotificationInput(params: {
+  guidePath: string;
+  memberIds: readonly string[];
+  confirmationText: string;
+  testMode?: boolean;
+}): AdminNotificationComposerInput {
+  const memberIds = Array.from(
+    new Set(params.memberIds.map((memberId) => memberId.trim()).filter(Boolean)),
+  );
+  if (memberIds.length === 0) {
+    throw new Error("발송 대상 당첨자를 찾을 수 없습니다.");
+  }
+
+  const title = params.testMode
+    ? "[테스트] 싸트너십 추첨권 이벤트 당첨 안내"
+    : "싸트너십 추첨권 이벤트 당첨 안내";
+  const body = params.testMode
+    ? "운영 테스트 발송입니다. 실제 당첨 안내가 아니며, 구글폼은 로그인한 당첨자에게만 노출됩니다."
+    : "축하합니다. 기프티콘 발송 정보 입력을 위해 당첨 안내 페이지에서 구글폼을 확인해 주세요.";
+
+  return {
+    notificationType: "announcement",
+    title,
+    body,
+    url: params.guidePath,
+    audience: {
+      scope: "member",
+      memberIds,
+    },
+    channels: {
+      in_app: true,
+      push: true,
+      mm: true,
+    },
+    confirmationText: params.confirmationText,
+  };
+}
+
+async function getEventRewardDrawRowForNotification(
+  drawId: string,
+  eventSlug?: string,
+) {
   const supabase = getSupabaseAdminClient();
-  const { data: drawRow, error: drawError } = await supabase
+  let query = supabase
     .from("event_reward_draws")
     .select(
       "id,event_slug,status,seed,winner_count,candidate_count,total_tickets,google_form_url,guide_path,sent_notification_id,metadata,created_by_admin_id,created_at,finalized_at,sent_at,updated_at",
     )
-    .eq("id", drawId)
-    .maybeSingle();
+    .eq("id", drawId);
+  if (eventSlug) {
+    query = query.eq("event_slug", eventSlug);
+  }
+  const { data: drawRow, error: drawError } = await query.maybeSingle();
   if (drawError) {
     throw new Error(drawError.message);
   }
   if (!drawRow) {
     throw new Error("추첨 결과를 찾을 수 없습니다.");
   }
+  return { supabase, drawRow: drawRow as EventRewardDrawRow };
+}
+
+export async function sendEventRewardWinnerNotifications(
+  drawId: string,
+  input: { confirmationText?: unknown; eventSlug?: string },
+) {
+  const request = normalizeEventRewardWinnerNotificationRequest(input);
+  const { supabase, drawRow } = await getEventRewardDrawRowForNotification(
+    drawId,
+    input.eventSlug,
+  );
   if (
     isEventRewardNotificationSendComplete(
       drawRow.status as EventRewardDrawStatus,
@@ -983,22 +1067,13 @@ export async function sendEventRewardWinnerNotifications(drawId: string) {
     throw new Error("당첨자가 없습니다.");
   }
 
-  const result = await sendAdminNotificationCampaign({
-    notificationType: "announcement",
-    title: "싸트너십 추첨권 이벤트 당첨 안내",
-    body: "축하합니다. 기프티콘 발송 정보 입력을 위해 당첨 안내 페이지에서 구글폼을 확인해 주세요.",
-    url: drawRow.guide_path,
-    audience: {
-      scope: "member",
+  const result = await sendAdminNotificationCampaign(
+    buildEventRewardWinnerNotificationInput({
+      guidePath: drawRow.guide_path,
       memberIds,
-    },
-    channels: {
-      in_app: true,
-      push: true,
-      mm: true,
-    },
-    confirmationText: "알림 발송",
-  });
+      confirmationText: request.confirmationText,
+    }),
+  );
 
   const aggregate = Object.values(result.channelResults).reduce(
     (accumulator, channel) => ({
@@ -1045,6 +1120,42 @@ export async function sendEventRewardWinnerNotifications(drawId: string) {
 
   return {
     status,
+    notificationId: result.notificationId,
+    channelResults: result.channelResults,
+    warnings: result.warnings,
+  };
+}
+
+export async function sendEventRewardWinnerTestNotification(
+  drawId: string,
+  input: { memberId?: unknown; eventSlug?: string },
+) {
+  const request = normalizeEventRewardTestNotificationRequest(input);
+  const { drawRow } = await getEventRewardDrawRowForNotification(
+    drawId,
+    input.eventSlug,
+  );
+
+  const result = await sendAdminNotificationCampaign(
+    buildEventRewardWinnerNotificationInput({
+      guidePath: drawRow.guide_path,
+      memberIds: [request.memberId],
+      confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+      testMode: true,
+    }),
+  );
+
+  return {
+    status: drawNotificationStatus(
+      Object.values(result.channelResults).reduce(
+        (accumulator, channel) => ({
+          targeted: accumulator.targeted + channel.targeted,
+          sent: accumulator.sent + channel.sent,
+          failed: accumulator.failed + channel.failed,
+        }),
+        { targeted: 0, sent: 0, failed: 0 },
+      ),
+    ),
     notificationId: result.notificationId,
     channelResults: result.channelResults,
     warnings: result.warnings,

--- a/tests/event-reward-admin.test.mts
+++ b/tests/event-reward-admin.test.mts
@@ -279,6 +279,74 @@ test("event reward draw input validates winner count and Google Forms URL", asyn
   );
 });
 
+test("event reward winner notification requires explicit confirmation text", async () => {
+  const {
+    EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+    normalizeEventRewardWinnerNotificationRequest,
+  } = await eventRewardsModulePromise;
+
+  assert.throws(
+    () =>
+      normalizeEventRewardWinnerNotificationRequest({
+        confirmationText: "",
+      }),
+    /확인 문구/,
+  );
+  assert.deepEqual(
+    normalizeEventRewardWinnerNotificationRequest({
+      confirmationText: ` ${EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT} `,
+    }),
+    {
+      confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+    },
+  );
+});
+
+test("event reward test notification input requires a target member", async () => {
+  const { normalizeEventRewardTestNotificationRequest } =
+    await eventRewardsModulePromise;
+
+  assert.throws(
+    () => normalizeEventRewardTestNotificationRequest({ memberId: " " }),
+    /테스트 수신자/,
+  );
+  assert.deepEqual(
+    normalizeEventRewardTestNotificationRequest({ memberId: " member-1 " }),
+    { memberId: "member-1" },
+  );
+});
+
+test("event reward notification payload separates test and final send copy", async () => {
+  const {
+    EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+    buildEventRewardWinnerNotificationInput,
+  } = await eventRewardsModulePromise;
+
+  const finalInput = buildEventRewardWinnerNotificationInput({
+    guidePath: "/events/signup-reward/winner-form",
+    memberIds: ["member-1", "member-2"],
+    confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+  });
+  const testInput = buildEventRewardWinnerNotificationInput({
+    guidePath: "/events/signup-reward/winner-form",
+    memberIds: ["member-test"],
+    confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
+    testMode: true,
+  });
+
+  assert.equal(finalInput.title, "싸트너십 추첨권 이벤트 당첨 안내");
+  assert.deepEqual(finalInput.audience, {
+    scope: "member",
+    memberIds: ["member-1", "member-2"],
+  });
+  assert.match(testInput.title, /\[테스트\]/);
+  assert.match(testInput.body, /운영 테스트/);
+  assert.deepEqual(testInput.audience, {
+    scope: "member",
+    memberIds: ["member-test"],
+  });
+});
+
 test("event reward winner notification failures stay retryable", async () => {
   const {
     isEventRewardNotificationSendComplete,


### PR DESCRIPTION
## Summary
- dev에 병합된 이벤트 당첨 안내 테스트 발송 및 실제 발송 확인 절차를 main으로 승격합니다.

## Related Issue
Closes #41

## Branch Flow
- `feat/event-reward-send-test-confirm` -> `dev` (#42)
- `dev` -> `main`

## Changes
- 이벤트 운영 페이지에 테스트 발송 폼과 실제 발송 확인 문구 입력 UI를 추가했습니다.
- 실제 발송 server action은 확인 문구와 event slug/draw id 매칭을 검증합니다.
- 테스트 발송은 별도 문구로 발송하고 draw/winner 발송 상태를 변경하지 않습니다.

## Test Plan
- PR #42 checks passed: lockfile, Vercel, Chromatic publish, UI Tests
- `node --import ./tests/alias-register.mjs --test tests/event-reward-admin.test.mts tests/event-rewards.test.mts`
- `npx eslint <changed files>`
- `npm run build`
- `npm run release`

## Checklist
- [x] dev PR merged
- [x] Preview deployment passed
- [x] Production promotion PR created
