### PR TITLE
fix: 추첨 전 당첨 안내 테스트 버튼 표시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/admin/(protected)/_actions/promotion-actions.ts
+++ b/src/app/admin/(protected)/_actions/promotion-actions.ts
@@ -496,7 +496,7 @@ export async function sendEventRewardWinnerNotificationsAction(formData: FormDat
 export async function sendEventRewardWinnerTestNotificationAction(formData: FormData) {
   await requireAdmin();
   const slug = normalizeSlug(getRequiredString(formData, "slug"));
-  const drawId = getRequiredString(formData, "drawId");
+  const drawId = getString(formData, "drawId") || null;
   const memberId = getRequiredString(formData, "memberId");
   const result = await sendEventRewardWinnerTestNotification(drawId, {
     eventSlug: slug,
@@ -505,9 +505,10 @@ export async function sendEventRewardWinnerTestNotificationAction(formData: Form
 
   await logAdminAction("event_reward_winner_notification_test_send", {
     targetType: "event_reward_draw",
-    targetId: drawId,
+    targetId: drawId ?? slug,
     properties: {
       eventSlug: slug,
+      drawId,
       memberId,
       status: result.status,
       notificationId: result.notificationId,

--- a/src/app/admin/(protected)/event/[slug]/page.tsx
+++ b/src/app/admin/(protected)/event/[slug]/page.tsx
@@ -192,6 +192,48 @@ function SignupRewardOverviewSection({
           ) : null}
         </div>
 
+        <form
+          action={sendEventRewardWinnerTestNotificationAction}
+          className="grid gap-3 rounded-[1rem] border border-border/70 bg-surface-inset p-4"
+        >
+          <input type="hidden" name="slug" value="signup-reward" />
+          {draw ? <input type="hidden" name="drawId" value={draw.id} /> : null}
+          <div>
+            <p className="text-sm font-semibold text-foreground">테스트 발송</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              앱+MM+푸시 채널로 테스트 안내를 보냅니다.
+            </p>
+          </div>
+          <label className="grid gap-2 text-sm font-medium text-foreground">
+            수신자
+            <select
+              name="memberId"
+              required
+              defaultValue=""
+              disabled={testRecipientOptions.length === 0}
+              className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground disabled:opacity-60"
+            >
+              <option value="" disabled>
+                테스트 수신자 선택
+              </option>
+              {testRecipientOptions.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.label} · {member.meta}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              variant="secondary"
+              disabled={testRecipientOptions.length === 0}
+            >
+              테스트 발송
+            </Button>
+          </div>
+        </form>
+
         {draw ? (
           <div className="grid gap-4">
             <StatsRow
@@ -242,81 +284,42 @@ function SignupRewardOverviewSection({
                 </tbody>
               </table>
             </div>
-            <div className="grid gap-3 lg:grid-cols-2">
+            {!draw.sentAt ? (
               <form
-                action={sendEventRewardWinnerTestNotificationAction}
-                className="grid gap-3 rounded-[1rem] border border-border/70 bg-surface-inset p-4"
+                action={sendEventRewardWinnerNotificationsAction}
+                className="grid gap-3 rounded-[1rem] border border-primary/20 bg-primary-soft p-4"
               >
                 <input type="hidden" name="slug" value="signup-reward" />
                 <input type="hidden" name="drawId" value={draw.id} />
                 <div>
-                  <p className="text-sm font-semibold text-foreground">테스트 발송</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    앱+MM+푸시 채널로 테스트 안내를 보냅니다.
+                  <p className="text-sm font-semibold text-primary">실제 발송</p>
+                  <p className="mt-1 text-xs text-primary/80">
+                    당첨자 {draw.winners.length.toLocaleString()}명에게 앱+MM+푸시 안내를 보냅니다.
                   </p>
                 </div>
-                <label className="grid gap-2 text-sm font-medium text-foreground">
-                  수신자
-                  <select
-                    name="memberId"
+                <label className="grid gap-2 text-sm font-medium text-primary">
+                  확인 문구
+                  <input
+                    name="confirmationText"
                     required
-                    defaultValue=""
-                    className="h-11 rounded-input border border-border bg-surface-control px-3 text-sm text-foreground"
-                  >
-                    <option value="" disabled>
-                      테스트 수신자 선택
-                    </option>
-                    {testRecipientOptions.map((member) => (
-                      <option key={member.id} value={member.id}>
-                        {member.label} · {member.meta}
-                      </option>
-                    ))}
-                  </select>
+                    pattern={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                    placeholder={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                    title={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
+                    className="h-11 rounded-input border border-primary/20 bg-surface-control px-3 text-sm text-foreground"
+                  />
                 </label>
                 <div className="flex justify-end">
-                  <Button type="submit" variant="secondary">
-                    테스트 발송
-                  </Button>
+                  <Button type="submit">발송 확인</Button>
                 </div>
               </form>
-
-              {!draw.sentAt ? (
-                <form
-                  action={sendEventRewardWinnerNotificationsAction}
-                  className="grid gap-3 rounded-[1rem] border border-primary/20 bg-primary-soft p-4"
-                >
-                  <input type="hidden" name="slug" value="signup-reward" />
-                  <input type="hidden" name="drawId" value={draw.id} />
-                  <div>
-                    <p className="text-sm font-semibold text-primary">실제 발송</p>
-                    <p className="mt-1 text-xs text-primary/80">
-                      당첨자 {draw.winners.length.toLocaleString()}명에게 앱+MM+푸시 안내를 보냅니다.
-                    </p>
-                  </div>
-                  <label className="grid gap-2 text-sm font-medium text-primary">
-                    확인 문구
-                    <input
-                      name="confirmationText"
-                      required
-                      pattern={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
-                      placeholder={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
-                      title={EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT}
-                      className="h-11 rounded-input border border-primary/20 bg-surface-control px-3 text-sm text-foreground"
-                    />
-                  </label>
-                  <div className="flex justify-end">
-                    <Button type="submit">발송 확인</Button>
-                  </div>
-                </form>
-              ) : (
-                <div className="rounded-[1rem] border border-border/70 bg-surface-inset p-4">
-                  <p className="text-sm font-semibold text-foreground">발송 완료</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {formatEventDate(draw.sentAt)}
-                  </p>
-                </div>
-              )}
-            </div>
+            ) : (
+              <div className="rounded-[1rem] border border-border/70 bg-surface-inset p-4">
+                <p className="text-sm font-semibold text-foreground">발송 완료</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {formatEventDate(draw.sentAt)}
+                </p>
+              </div>
+            )}
           </div>
         ) : (
           <form action={createEventRewardDrawAction} className="grid gap-4">

--- a/src/lib/promotions/event-rewards.ts
+++ b/src/lib/promotions/event-rewards.ts
@@ -879,7 +879,7 @@ export async function createStoredEventRewardDraw(params: {
   });
   const supabase = getSupabaseAdminClient();
   const now = new Date().toISOString();
-  const guidePath = `/events/${params.campaign.slug}/winner-form`;
+  const guidePath = getEventRewardWinnerGuidePath(params.campaign.slug);
   const { data: draw, error: drawError } = await supabase
     .from("event_reward_draws")
     .insert({
@@ -968,6 +968,10 @@ export function isEventRewardNotificationSendComplete(
   sentAt: string | null,
 ) {
   return status === "sent" && Boolean(sentAt);
+}
+
+export function getEventRewardWinnerGuidePath(eventSlug: string) {
+  return `/events/${eventSlug}/winner-form`;
 }
 
 export function buildEventRewardWinnerNotificationInput(params: {
@@ -1127,18 +1131,22 @@ export async function sendEventRewardWinnerNotifications(
 }
 
 export async function sendEventRewardWinnerTestNotification(
-  drawId: string,
+  drawId: string | null,
   input: { memberId?: unknown; eventSlug?: string },
 ) {
   const request = normalizeEventRewardTestNotificationRequest(input);
-  const { drawRow } = await getEventRewardDrawRowForNotification(
-    drawId,
-    input.eventSlug,
-  );
+  const guidePath = drawId
+    ? (
+        await getEventRewardDrawRowForNotification(
+          drawId,
+          input.eventSlug,
+        )
+      ).drawRow.guide_path
+    : getEventRewardWinnerGuidePath(input.eventSlug ?? "signup-reward");
 
   const result = await sendAdminNotificationCampaign(
     buildEventRewardWinnerNotificationInput({
-      guidePath: drawRow.guide_path,
+      guidePath,
       memberIds: [request.memberId],
       confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
       testMode: true,

--- a/tests/event-reward-admin.test.mts
+++ b/tests/event-reward-admin.test.mts
@@ -320,6 +320,7 @@ test("event reward notification payload separates test and final send copy", asy
   const {
     EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
     buildEventRewardWinnerNotificationInput,
+    getEventRewardWinnerGuidePath,
   } = await eventRewardsModulePromise;
 
   const finalInput = buildEventRewardWinnerNotificationInput({
@@ -328,7 +329,7 @@ test("event reward notification payload separates test and final send copy", asy
     confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
   });
   const testInput = buildEventRewardWinnerNotificationInput({
-    guidePath: "/events/signup-reward/winner-form",
+    guidePath: getEventRewardWinnerGuidePath("signup-reward"),
     memberIds: ["member-test"],
     confirmationText: EVENT_REWARD_WINNER_NOTIFICATION_CONFIRMATION_TEXT,
     testMode: true,
@@ -341,6 +342,7 @@ test("event reward notification payload separates test and final send copy", asy
   });
   assert.match(testInput.title, /\[테스트\]/);
   assert.match(testInput.body, /운영 테스트/);
+  assert.equal(testInput.url, "/events/signup-reward/winner-form");
   assert.deepEqual(testInput.audience, {
     scope: "member",
     memberIds: ["member-test"],


### PR DESCRIPTION
## Summary
- 추첨 결과가 아직 없을 때도 이벤트 운영 페이지에서 당첨 안내 테스트 발송 폼이 보이도록 이동했습니다.
- 테스트 발송 액션의 drawId를 선택값으로 바꾸고, 추첨 전에는 이벤트별 winner-form 내부 안내 URL을 사용하도록 했습니다.
- 안내 URL 생성 헬퍼를 공유하고 관련 테스트를 갱신했습니다.
- patch 버전을 1.10.2로 올렸습니다.

## Branch Flow
- hotfix/event-reward-test-button-visible -> main
- main 병합 후 dev 동기화 예정

## Test Plan
- node --import ./tests/alias-register.mjs --test tests/event-reward-admin.test.mts tests/event-rewards.test.mts
- npx eslint src/lib/promotions/event-rewards.ts src/app/admin/'(protected)'/_actions/promotion-actions.ts src/app/admin/'(protected)'/event/'[slug]'/page.tsx tests/event-reward-admin.test.mts
- npm run build
- npm run release (patch, Storybook build + Storybook interaction/smoke tests)
- Playwright 로컬 확인: /admin/event/signup-reward 에서 테스트 발송 버튼 1개 활성화 확인