### PR TITLE
chore: 공개 readiness 보완

### DIFF
--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: Install Playwright browser
-        run: npx playwright install chromium
+        run: npx playwright install --only-shell chromium
 
       - name: E2E tests
         run: npm run test:e2e

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -48,7 +48,14 @@ jobs:
       - name: Production build
         run: npm run build
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browser
+        timeout-minutes: 8
         run: npx playwright install --only-shell chromium
 
       - name: E2E tests

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm run build
 
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: E2E tests
         run: npm run test:e2e

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -48,15 +48,7 @@ jobs:
       - name: Production build
         run: npm run build
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browser
-        timeout-minutes: 8
-        run: npx playwright install --only-shell chromium
-
       - name: E2E tests
+        env:
+          PLAYWRIGHT_CHROMIUM_CHANNEL: chrome
         run: npm run test:e2e

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -1,0 +1,55 @@
+name: Public Readiness
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Lint, Test, Build, Security, E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify lockfile
+        run: npm run check:lockfile
+
+      - name: Validate migrations
+        run: npm run validate:migrations
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit --pretty false
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Dependency audit
+        run: npm audit --omit=dev
+
+      - name: Security audit
+        run: npm run audit:security
+
+      - name: Production build
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: npm run test:e2e

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# SSARTNERSHIP Security Policy
+
+SSARTNERSHIP is a public repository and production service for SSAFY member
+partnership operations. Please report suspected security issues privately before
+sharing details in public issues, discussions, pull requests, or social channels.
+
+## Reporting
+
+Email reports to `myknow@ssafy.com` with the subject prefix `[SSARTNERSHIP Security]`.
+
+Include:
+
+- Affected URL, API route, or repository path
+- Reproduction steps and expected impact
+- Any request IDs or timestamps that help locate server logs
+- Whether personal data, credentials, tokens, or private member information may be affected
+
+Do not include more personal data than is necessary to demonstrate the issue.
+
+## Safe Testing
+
+- Do not access, modify, delete, or exfiltrate another user's personal data.
+- Do not run denial-of-service, spam, credential stuffing, or destructive tests.
+- Do not attempt to bypass SSAFY Verify, Supabase, Vercel, or Mattermost controls beyond the minimum proof needed for the report.
+- Stop testing and report immediately if you encounter secrets, service-role keys, private tokens, production database URLs, or member data.
+
+## Response
+
+This project is operated by a small team. Security reports are triaged as soon as
+possible, with credential rotation and mitigation prioritized for confirmed
+exposure of secrets, authentication bypasses, authorization bypasses, and personal
+data leaks.

--- a/docs/product/todo.md
+++ b/docs/product/todo.md
@@ -2,7 +2,21 @@
 
 정렬 기준: 영향 범위 × 위험도 × 구현 효과. 위에 있는 항목일수록 먼저 처리한다.
 
-최종 점검: 2026-04-23
+최종 점검: 2026-06-23
+
+## 공개 readiness 보완 (Issue #55)
+
+- [x] SSAFY Verify Server API Production env 등록
+- [ ] Production 재배포 후 Verify profile-sync 라이브 스모크
+- [x] GitHub Actions 공개 readiness gate 추가
+- [x] 공개 저장소용 `SECURITY.md` responsible disclosure 정책 추가
+- [x] 파트너 상세 대표 이미지 LCP/CLS 개선
+- [x] `main` 브랜치 보호 규칙과 required status checks 적용
+- [ ] 관리자 edge perimeter hardening 값 확정: `ADMIN_ALLOWED_IPS` 또는 Basic Auth
+- [ ] Vercel legacy Mattermost env 제거: 명시 승인 후 `MM_*`, `NEXT_PUBLIC_MATTERMOST_DM_URL` 삭제
+
+주의: 관리자 IP allowlist와 Basic Auth는 운영자 접속을 잠글 수 있어 값 확정 후 적용한다.
+legacy Mattermost env 제거는 예전 직접 연동 배포로 롤백할 수 없게 만들 수 있어 별도 승인 후 적용한다.
 
 1. [x] 공개 레이아웃의 세션 및 정책 조회 비용 줄이기
    대상: `src/app/(site)/layout.tsx`, `src/lib/user-auth.ts`, `src/lib/policy-documents.ts`

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video: chromiumChannel ? "off" : "retain-on-failure",
   },
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const e2ePort = process.env.E2E_PORT ?? "3100";
 const baseURL = process.env.BASE_URL ?? `http://127.0.0.1:${e2ePort}`;
+const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL === "chrome" ? "chrome" : undefined;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -23,7 +24,10 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(chromiumChannel ? { channel: chromiumChannel } : {}),
+      },
     },
   ],
   webServer: process.env.BASE_URL

--- a/src/components/PartnerImageCarousel.tsx
+++ b/src/components/PartnerImageCarousel.tsx
@@ -101,6 +101,7 @@ export default function PartnerImageCarousel({
             fill
             sizes="(max-width: 1279px) 100vw, 50vw"
             className="object-cover"
+            fetchPriority={priority ? "high" : undefined}
             loading={priority ? undefined : "eager"}
             priority={priority}
             unoptimized={isProxiedCachedImageUrl(activeImage)}

--- a/src/components/partner-image-carousel/ThumbStrip.tsx
+++ b/src/components/partner-image-carousel/ThumbStrip.tsx
@@ -53,7 +53,8 @@ export default function ThumbStrip({
             className="h-full w-full object-cover"
             sizes={placement === "side" ? "120px" : "(min-width: 1280px) 15vw, 96px"}
             unoptimized
-            loading="eager"
+            loading="lazy"
+            fetchPriority="low"
           />
         </button>
       ))}

--- a/src/components/partner-image-carousel/useCarouselController.ts
+++ b/src/components/partner-image-carousel/useCarouselController.ts
@@ -7,14 +7,12 @@ import {
 } from "@/lib/image-cache";
 import {
   clampCarouselZoom,
-  getDesktopThumbPlacement,
   normalizeCarouselIndex,
 } from "./helpers";
 import type { CarouselOffset, CarouselThumbPlacement } from "./types";
 
 export function useCarouselController({
   images,
-  matchHeightSelector,
 }: {
   images: string[];
   matchHeightSelector?: string;
@@ -38,8 +36,7 @@ export function useCarouselController({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const activeThumbRef = useRef<HTMLButtonElement | null>(null);
   const thumbStripRef = useRef<HTMLDivElement | null>(null);
-  const [thumbPlacement, setThumbPlacement] =
-    useState<CarouselThumbPlacement>("side");
+  const thumbPlacement = useMemo<CarouselThumbPlacement>(() => "bottom", []);
   useEffect(() => {
     if (typeof document === "undefined") {
       return;
@@ -107,62 +104,6 @@ export function useCarouselController({
       inline: "center",
     });
   }, [activeIndex, thumbPlacement]);
-
-  useEffect(() => {
-    if (!matchHeightSelector || typeof window === "undefined") {
-      return;
-    }
-
-    const media = window.matchMedia("(min-width: 1280px)");
-    let observer: ResizeObserver | null = null;
-    let rootObserver: ResizeObserver | null = null;
-
-    const syncLayout = () => {
-      if (!media.matches) {
-        setThumbPlacement("side");
-        return;
-      }
-      const root = rootRef.current;
-      const target = document.querySelector(matchHeightSelector);
-      if (!(root instanceof HTMLElement) || !(target instanceof HTMLElement)) {
-        setThumbPlacement("side");
-        return;
-      }
-      setThumbPlacement(
-        getDesktopThumbPlacement({
-          containerWidth: root.getBoundingClientRect().width,
-          targetHeight: target.getBoundingClientRect().height,
-          imageCount,
-        }),
-      );
-    };
-
-    if (rootRef.current instanceof HTMLElement) {
-      rootObserver = new ResizeObserver(() => {
-        syncLayout();
-      });
-      rootObserver.observe(rootRef.current);
-    }
-
-    const target = document.querySelector(matchHeightSelector);
-    if (target instanceof HTMLElement) {
-      observer = new ResizeObserver(() => {
-        syncLayout();
-      });
-      observer.observe(target);
-    }
-
-    syncLayout();
-    media.addEventListener("change", syncLayout);
-    window.addEventListener("resize", syncLayout);
-
-    return () => {
-      observer?.disconnect();
-      rootObserver?.disconnect();
-      media.removeEventListener("change", syncLayout);
-      window.removeEventListener("resize", syncLayout);
-    };
-  }, [imageCount, matchHeightSelector]);
 
   const resetInteractiveState = () => {
     setZoom(1);

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -23,7 +23,7 @@ test("public readiness CI workflow gates launch-critical checks", () => {
     "npm audit --omit=dev",
     "npm run audit:security",
     "npm run build",
-    "npx playwright install chromium",
+    "npx playwright install --only-shell chromium",
     "npm run test:e2e",
   ]) {
     assert.match(workflow, new RegExp(requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -23,7 +23,7 @@ test("public readiness CI workflow gates launch-critical checks", () => {
     "npm audit --omit=dev",
     "npm run audit:security",
     "npm run build",
-    "npx playwright install --with-deps chromium",
+    "npx playwright install chromium",
     "npm run test:e2e",
   ]) {
     assert.match(workflow, new RegExp(requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+function readRepoFile(pathname: string) {
+  return readFileSync(new URL(`../${pathname}`, import.meta.url), "utf8");
+}
+
+test("public readiness CI workflow gates launch-critical checks", () => {
+  const workflow = readRepoFile(".github/workflows/public-readiness.yml");
+
+  for (const requiredText of [
+    "name: Public Readiness",
+    "pull_request:",
+    "workflow_dispatch:",
+    "npm ci",
+    "npm run check:lockfile",
+    "npm run validate:migrations",
+    "npm run lint",
+    "npx tsc --noEmit --pretty false",
+    "npm test",
+    "npm audit --omit=dev",
+    "npm run audit:security",
+    "npm run build",
+    "npx playwright install --with-deps chromium",
+    "npm run test:e2e",
+  ]) {
+    assert.match(workflow, new RegExp(requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
+test("public repository exposes a responsible disclosure security policy", () => {
+  const securityPolicy = readRepoFile("SECURITY.md");
+
+  assert.match(securityPolicy, /SSARTNERSHIP Security Policy/);
+  assert.match(securityPolicy, /myknow@ssafy\.com/);
+  assert.match(securityPolicy, /public/i);
+  assert.match(securityPolicy, /personal data/i);
+});
+
+test("public readiness TODO keeps the launch blocker remediation tracked", () => {
+  const todo = readRepoFile("docs/product/todo.md");
+
+  assert.match(todo, /공개 readiness 보완/);
+  assert.match(todo, /Issue #55/);
+  assert.match(todo, /SSAFY Verify Server API Production env/);
+  assert.match(todo, /GitHub Actions 공개 readiness gate/);
+});

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -23,6 +23,9 @@ test("public readiness CI workflow gates launch-critical checks", () => {
     "npm audit --omit=dev",
     "npm run audit:security",
     "npm run build",
+    "actions/cache@v4",
+    "key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}",
+    "timeout-minutes: 8",
     "npx playwright install --only-shell chromium",
     "npm run test:e2e",
   ]) {

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -13,6 +13,7 @@ test("public readiness CI workflow gates launch-critical checks", () => {
     "name: Public Readiness",
     "pull_request:",
     "workflow_dispatch:",
+    "node-version: 24",
     "npm ci",
     "npm run check:lockfile",
     "npm run validate:migrations",

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -35,6 +35,7 @@ test("playwright config can use the CI-hosted Chrome channel", () => {
 
   assert.match(config, /PLAYWRIGHT_CHROMIUM_CHANNEL/);
   assert.match(config, /channel: chromiumChannel/);
+  assert.match(config, /video: chromiumChannel \? "off" : "retain-on-failure"/);
 });
 
 test("public repository exposes a responsible disclosure security policy", () => {

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -23,14 +23,18 @@ test("public readiness CI workflow gates launch-critical checks", () => {
     "npm audit --omit=dev",
     "npm run audit:security",
     "npm run build",
-    "actions/cache@v4",
-    "key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}",
-    "timeout-minutes: 8",
-    "npx playwright install --only-shell chromium",
+    "PLAYWRIGHT_CHROMIUM_CHANNEL: chrome",
     "npm run test:e2e",
   ]) {
     assert.match(workflow, new RegExp(requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
+});
+
+test("playwright config can use the CI-hosted Chrome channel", () => {
+  const config = readRepoFile("playwright.config.ts");
+
+  assert.match(config, /PLAYWRIGHT_CHROMIUM_CHANNEL/);
+  assert.match(config, /channel: chromiumChannel/);
 });
 
 test("public repository exposes a responsible disclosure security policy", () => {


### PR DESCRIPTION
## Summary
- 공개 readiness TODO를 Issue #55로 추적하고 CI/보안정책/성능 보완을 반영합니다.
- Vercel Production에 SSAFY Verify Server API credential env를 등록했고, main 브랜치 보호 규칙을 적용했습니다.

## Related Issue
Refs #55

## Branch Flow
- `chore/public-readiness-hardening` -> `dev`
- Preview 검증 후 `dev` -> `main`

## Changes
- GitHub Actions `Public Readiness` workflow 추가
- `SECURITY.md` responsible disclosure 정책 추가
- 공개 readiness TODO 항목 추가 및 적용 상태 반영
- 파트너 상세 캐러셀의 썸네일 배치를 안정화하고 대표 이미지 fetch priority 개선
- CI/보안정책/TODO 계약 테스트 추가

## External Operations
- Vercel Production: `SSAFY_VERIFY_SERVER_CLIENT_ID`, `SSAFY_VERIFY_SERVER_CLIENT_SECRET` 등록 완료
- Vercel Preview: 동일 키 기존 존재 확인
- GitHub main protection: required checks `lockfile`, `Publish Storybook to Chromatic`, `Lint, Test, Build, Security, E2E` 적용

## Test Plan
- [x] `npm run check:lockfile`
- [x] `npm run lint`
- [x] `npx tsc --noEmit --pretty false`
- [x] `npm test` (217 tests)
- [x] `npm audit --omit=dev`
- [x] `npm run audit:security`
- [x] `npm run validate:migrations`
- [x] `npm run build`
- [x] `npm run test:e2e` (48 tests)
- [x] `npm run perf:lighthouse` (28 public pages, worst 94%)
- [x] `npm run build-storybook`
- [x] `npm run test-storybook` (68 files, 166 tests)

## Checklist
- [x] 변경 범위를 Issue #55에 연결했습니다.
- [x] 민감 값은 커밋하지 않았습니다.
- [x] 운영 설정 변경은 값 노출 없이 확인했습니다.
- [ ] Preview 배포 후 Verify profile-sync live smoke를 수행합니다.
