### PR TITLE
chore: 공개 readiness 보완 production 승격

### DIFF
--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -1,0 +1,54 @@
+name: Public Readiness
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Lint, Test, Build, Security, E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify lockfile
+        run: npm run check:lockfile
+
+      - name: Validate migrations
+        run: npm run validate:migrations
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit --pretty false
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Dependency audit
+        run: npm audit --omit=dev
+
+      - name: Security audit
+        run: npm run audit:security
+
+      - name: Production build
+        run: npm run build
+
+      - name: E2E tests
+        env:
+          PLAYWRIGHT_CHROMIUM_CHANNEL: chrome
+        run: npm run test:e2e

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,8 +1,6 @@
 name: Publish Storybook
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ npm run build-storybook
 npm run test-storybook
 ```
 
-Chromatic 빌드 에러를 push 이후에 발견하지 않도록, 릴리즈 흐름에서는 `npm run build-storybook`과 `npm run test-storybook`을 커밋/푸시 전에 반드시 통과해야 합니다. Storybook 빌드가 실패하면 `npm run release`는 버전 업데이트, 커밋, 푸시를 진행하지 않습니다.
+릴리즈 흐름에서는 `npm run build-storybook`과 `npm run test-storybook`을 커밋/푸시 전에 반드시 통과해야 합니다. Storybook 빌드가 실패하면 `npm run release`는 버전 업데이트, 커밋, 푸시를 진행하지 않습니다. Chromatic publish GitHub Actions는 무료 한도 소진으로 인한 외부 `UI Tests` pending을 피하기 위해 수동 실행 전용입니다.
 
 ### release 스크립트
 
@@ -484,7 +484,7 @@ EOF
 - `main` 외 브랜치에서는 태그를 만들지 않습니다.
 - 작업 트리가 비어 있어도 `patch`, `minor`, `major`를 선택하면 버전 업데이트로 릴리즈할 수 있습니다.
 - 작업 트리가 비어 있는 상태에서 `no update`를 선택하면 종료됩니다.
-- Storybook build/test가 실패하면 Chromatic 이메일이 오기 전에 로컬 release 단계에서 차단되므로, 실패 원인을 먼저 수정한 뒤 다시 release를 실행해야 합니다.
+- Storybook build/test가 실패하면 로컬 release 단계에서 차단되므로, 실패 원인을 먼저 수정한 뒤 다시 release를 실행해야 합니다.
 
 ## 배포
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# SSARTNERSHIP Security Policy
+
+SSARTNERSHIP is a public repository and production service for SSAFY member
+partnership operations. Please report suspected security issues privately before
+sharing details in public issues, discussions, pull requests, or social channels.
+
+## Reporting
+
+Email reports to `myknow@ssafy.com` with the subject prefix `[SSARTNERSHIP Security]`.
+
+Include:
+
+- Affected URL, API route, or repository path
+- Reproduction steps and expected impact
+- Any request IDs or timestamps that help locate server logs
+- Whether personal data, credentials, tokens, or private member information may be affected
+
+Do not include more personal data than is necessary to demonstrate the issue.
+
+## Safe Testing
+
+- Do not access, modify, delete, or exfiltrate another user's personal data.
+- Do not run denial-of-service, spam, credential stuffing, or destructive tests.
+- Do not attempt to bypass SSAFY Verify, Supabase, Vercel, or Mattermost controls beyond the minimum proof needed for the report.
+- Stop testing and report immediately if you encounter secrets, service-role keys, private tokens, production database URLs, or member data.
+
+## Response
+
+This project is operated by a small team. Security reports are triaged as soon as
+possible, with credential rotation and mitigation prioritized for confirmed
+exposure of secrets, authentication bypasses, authorization bypasses, and personal
+data leaks.

--- a/docs/product/todo.md
+++ b/docs/product/todo.md
@@ -2,7 +2,21 @@
 
 정렬 기준: 영향 범위 × 위험도 × 구현 효과. 위에 있는 항목일수록 먼저 처리한다.
 
-최종 점검: 2026-04-23
+최종 점검: 2026-06-23
+
+## 공개 readiness 보완 (Issue #55)
+
+- [x] SSAFY Verify Server API Production env 등록
+- [ ] Production 재배포 후 Verify profile-sync 라이브 스모크
+- [x] GitHub Actions 공개 readiness gate 추가
+- [x] 공개 저장소용 `SECURITY.md` responsible disclosure 정책 추가
+- [x] 파트너 상세 대표 이미지 LCP/CLS 개선
+- [x] `main` 브랜치 보호 규칙과 required status checks 적용
+- [ ] 관리자 edge perimeter hardening 값 확정: `ADMIN_ALLOWED_IPS` 또는 Basic Auth
+- [ ] Vercel legacy Mattermost env 제거: 명시 승인 후 `MM_*`, `NEXT_PUBLIC_MATTERMOST_DM_URL` 삭제
+
+주의: 관리자 IP allowlist와 Basic Auth는 운영자 접속을 잠글 수 있어 값 확정 후 적용한다.
+legacy Mattermost env 제거는 예전 직접 연동 배포로 롤백할 수 없게 만들 수 있어 별도 승인 후 적용한다.
 
 1. [x] 공개 레이아웃의 세션 및 정책 조회 비용 줄이기
    대상: `src/app/(site)/layout.tsx`, `src/lib/user-auth.ts`, `src/lib/policy-documents.ts`

--- a/docs/testing/storybook.md
+++ b/docs/testing/storybook.md
@@ -38,15 +38,15 @@ npm run test-storybook
 npm run test-storybook:watch
 ```
 
-## 강제 게이트
+## 검증 게이트
 
-Chromatic 빌드 에러가 push 이후 이메일로만 발견되는 상황을 막기 위해 Storybook 검증을 릴리즈 게이트로 둡니다.
+Storybook 자체 검증은 로컬 릴리즈 게이트로 유지합니다.
 
 - `npm run release`는 커밋/푸시 전에 `npm run build-storybook`을 반드시 실행합니다.
 - `npm run release`는 커밋/푸시 전에 `npm run test-storybook`을 반드시 실행합니다.
 - 두 명령 중 하나라도 실패하면 버전 업데이트, 커밋, 푸시를 진행하지 않습니다.
-- GitHub Actions의 Chromatic workflow는 실패를 허용하지 않으므로, CI에서도 Storybook/Chromatic 실패가 명확히 실패로 남습니다.
-- 긴급 상황에서 `git push --no-verify`로 로컬 hook을 우회하더라도 release 스크립트와 CI 게이트는 우회하지 않는 것을 원칙으로 합니다.
+- GitHub Actions의 Chromatic publish workflow는 무료 한도 소진으로 인한 외부 `UI Tests` pending을 피하기 위해 수동 실행 전용입니다.
+- 긴급 상황에서 `git push --no-verify`로 로컬 hook을 우회하더라도 release 스크립트와 Public Readiness CI 게이트는 우회하지 않는 것을 원칙으로 합니다.
 
 ## 현재 포함된 스토리
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const e2ePort = process.env.E2E_PORT ?? "3100";
 const baseURL = process.env.BASE_URL ?? `http://127.0.0.1:${e2ePort}`;
+const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL === "chrome" ? "chrome" : undefined;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -18,12 +19,15 @@ export default defineConfig({
     baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video: chromiumChannel ? "off" : "retain-on-failure",
   },
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(chromiumChannel ? { channel: chromiumChannel } : {}),
+      },
     },
   ],
   webServer: process.env.BASE_URL

--- a/src/components/PartnerImageCarousel.tsx
+++ b/src/components/PartnerImageCarousel.tsx
@@ -101,6 +101,7 @@ export default function PartnerImageCarousel({
             fill
             sizes="(max-width: 1279px) 100vw, 50vw"
             className="object-cover"
+            fetchPriority={priority ? "high" : undefined}
             loading={priority ? undefined : "eager"}
             priority={priority}
             unoptimized={isProxiedCachedImageUrl(activeImage)}

--- a/src/components/partner-image-carousel/ThumbStrip.tsx
+++ b/src/components/partner-image-carousel/ThumbStrip.tsx
@@ -53,7 +53,8 @@ export default function ThumbStrip({
             className="h-full w-full object-cover"
             sizes={placement === "side" ? "120px" : "(min-width: 1280px) 15vw, 96px"}
             unoptimized
-            loading="eager"
+            loading="lazy"
+            fetchPriority="low"
           />
         </button>
       ))}

--- a/src/components/partner-image-carousel/useCarouselController.ts
+++ b/src/components/partner-image-carousel/useCarouselController.ts
@@ -7,14 +7,12 @@ import {
 } from "@/lib/image-cache";
 import {
   clampCarouselZoom,
-  getDesktopThumbPlacement,
   normalizeCarouselIndex,
 } from "./helpers";
 import type { CarouselOffset, CarouselThumbPlacement } from "./types";
 
 export function useCarouselController({
   images,
-  matchHeightSelector,
 }: {
   images: string[];
   matchHeightSelector?: string;
@@ -38,8 +36,7 @@ export function useCarouselController({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const activeThumbRef = useRef<HTMLButtonElement | null>(null);
   const thumbStripRef = useRef<HTMLDivElement | null>(null);
-  const [thumbPlacement, setThumbPlacement] =
-    useState<CarouselThumbPlacement>("side");
+  const thumbPlacement = useMemo<CarouselThumbPlacement>(() => "bottom", []);
   useEffect(() => {
     if (typeof document === "undefined") {
       return;
@@ -107,62 +104,6 @@ export function useCarouselController({
       inline: "center",
     });
   }, [activeIndex, thumbPlacement]);
-
-  useEffect(() => {
-    if (!matchHeightSelector || typeof window === "undefined") {
-      return;
-    }
-
-    const media = window.matchMedia("(min-width: 1280px)");
-    let observer: ResizeObserver | null = null;
-    let rootObserver: ResizeObserver | null = null;
-
-    const syncLayout = () => {
-      if (!media.matches) {
-        setThumbPlacement("side");
-        return;
-      }
-      const root = rootRef.current;
-      const target = document.querySelector(matchHeightSelector);
-      if (!(root instanceof HTMLElement) || !(target instanceof HTMLElement)) {
-        setThumbPlacement("side");
-        return;
-      }
-      setThumbPlacement(
-        getDesktopThumbPlacement({
-          containerWidth: root.getBoundingClientRect().width,
-          targetHeight: target.getBoundingClientRect().height,
-          imageCount,
-        }),
-      );
-    };
-
-    if (rootRef.current instanceof HTMLElement) {
-      rootObserver = new ResizeObserver(() => {
-        syncLayout();
-      });
-      rootObserver.observe(rootRef.current);
-    }
-
-    const target = document.querySelector(matchHeightSelector);
-    if (target instanceof HTMLElement) {
-      observer = new ResizeObserver(() => {
-        syncLayout();
-      });
-      observer.observe(target);
-    }
-
-    syncLayout();
-    media.addEventListener("change", syncLayout);
-    window.addEventListener("resize", syncLayout);
-
-    return () => {
-      observer?.disconnect();
-      rootObserver?.disconnect();
-      media.removeEventListener("change", syncLayout);
-      window.removeEventListener("resize", syncLayout);
-    };
-  }, [imageCount, matchHeightSelector]);
 
   const resetInteractiveState = () => {
     setZoom(1);

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+function readRepoFile(pathname: string) {
+  return readFileSync(new URL(`../${pathname}`, import.meta.url), "utf8");
+}
+
+test("public readiness CI workflow gates launch-critical checks", () => {
+  const workflow = readRepoFile(".github/workflows/public-readiness.yml");
+
+  for (const requiredText of [
+    "name: Public Readiness",
+    "pull_request:",
+    "workflow_dispatch:",
+    "node-version: 24",
+    "npm ci",
+    "npm run check:lockfile",
+    "npm run validate:migrations",
+    "npm run lint",
+    "npx tsc --noEmit --pretty false",
+    "npm test",
+    "npm audit --omit=dev",
+    "npm run audit:security",
+    "npm run build",
+    "PLAYWRIGHT_CHROMIUM_CHANNEL: chrome",
+    "npm run test:e2e",
+  ]) {
+    assert.match(workflow, new RegExp(requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
+test("playwright config can use the CI-hosted Chrome channel", () => {
+  const config = readRepoFile("playwright.config.ts");
+
+  assert.match(config, /PLAYWRIGHT_CHROMIUM_CHANNEL/);
+  assert.match(config, /channel: chromiumChannel/);
+  assert.match(config, /video: chromiumChannel \? "off" : "retain-on-failure"/);
+});
+
+test("public repository exposes a responsible disclosure security policy", () => {
+  const securityPolicy = readRepoFile("SECURITY.md");
+
+  assert.match(securityPolicy, /SSARTNERSHIP Security Policy/);
+  assert.match(securityPolicy, /myknow@ssafy\.com/);
+  assert.match(securityPolicy, /public/i);
+  assert.match(securityPolicy, /personal data/i);
+});
+
+test("public readiness TODO keeps the launch blocker remediation tracked", () => {
+  const todo = readRepoFile("docs/product/todo.md");
+
+  assert.match(todo, /공개 readiness 보완/);
+  assert.match(todo, /Issue #55/);
+  assert.match(todo, /SSAFY Verify Server API Production env/);
+  assert.match(todo, /GitHub Actions 공개 readiness gate/);
+});

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -30,6 +30,16 @@ test("public readiness CI workflow gates launch-critical checks", () => {
   }
 });
 
+test("Chromatic Storybook publish stays manual-only while free quota is exhausted", () => {
+  const workflow = readRepoFile(".github/workflows/storybook.yml");
+
+  assert.match(workflow, /name: Publish Storybook/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /chromaui\/action@latest/);
+  assert.doesNotMatch(workflow, /^\s+push:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s+pull_request:\s*$/m);
+});
+
 test("playwright config can use the CI-hosted Chrome channel", () => {
   const config = readRepoFile("playwright.config.ts");
 


### PR DESCRIPTION
## Summary
- 공개 readiness 보완 PR #56을 dev에서 검증 후 main으로 승격합니다.
- Public Readiness CI gate, SECURITY.md, 공개 readiness TODO, 파트너 상세 이미지/CLS 개선을 포함합니다.
- CI E2E는 GitHub hosted Chrome channel을 사용하도록 조정했습니다.

## Related Issue
- Refs #55

## Branch Flow
- chore/public-readiness-hardening -> dev: merged via PR #56
- dev -> main: this promotion PR

## Verification
- dev Public Readiness: pass (lint, typecheck, unit, audit, security audit, build, e2e)
- dev Verify Node Lockfile: pass
- dev Publish Storybook to Chromatic: pass
- Vercel protected preview fetch: / and /auth/signup return 200 OK

## Checklist
- [x] dev CI passed
- [x] dev preview smoke checked
- [ ] main CI passed
- [ ] production smoke checked after merge