### PR TITLE
ci: Chromatic 자동 실행 비활성화

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,8 +1,6 @@
 name: Publish Storybook
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ npm run build-storybook
 npm run test-storybook
 ```
 
-Chromatic 빌드 에러를 push 이후에 발견하지 않도록, 릴리즈 흐름에서는 `npm run build-storybook`과 `npm run test-storybook`을 커밋/푸시 전에 반드시 통과해야 합니다. Storybook 빌드가 실패하면 `npm run release`는 버전 업데이트, 커밋, 푸시를 진행하지 않습니다.
+릴리즈 흐름에서는 `npm run build-storybook`과 `npm run test-storybook`을 커밋/푸시 전에 반드시 통과해야 합니다. Storybook 빌드가 실패하면 `npm run release`는 버전 업데이트, 커밋, 푸시를 진행하지 않습니다. Chromatic publish GitHub Actions는 무료 한도 소진으로 인한 외부 `UI Tests` pending을 피하기 위해 수동 실행 전용입니다.
 
 ### release 스크립트
 
@@ -484,7 +484,7 @@ EOF
 - `main` 외 브랜치에서는 태그를 만들지 않습니다.
 - 작업 트리가 비어 있어도 `patch`, `minor`, `major`를 선택하면 버전 업데이트로 릴리즈할 수 있습니다.
 - 작업 트리가 비어 있는 상태에서 `no update`를 선택하면 종료됩니다.
-- Storybook build/test가 실패하면 Chromatic 이메일이 오기 전에 로컬 release 단계에서 차단되므로, 실패 원인을 먼저 수정한 뒤 다시 release를 실행해야 합니다.
+- Storybook build/test가 실패하면 로컬 release 단계에서 차단되므로, 실패 원인을 먼저 수정한 뒤 다시 release를 실행해야 합니다.
 
 ## 배포
 

--- a/docs/testing/storybook.md
+++ b/docs/testing/storybook.md
@@ -38,15 +38,15 @@ npm run test-storybook
 npm run test-storybook:watch
 ```
 
-## 강제 게이트
+## 검증 게이트
 
-Chromatic 빌드 에러가 push 이후 이메일로만 발견되는 상황을 막기 위해 Storybook 검증을 릴리즈 게이트로 둡니다.
+Storybook 자체 검증은 로컬 릴리즈 게이트로 유지합니다.
 
 - `npm run release`는 커밋/푸시 전에 `npm run build-storybook`을 반드시 실행합니다.
 - `npm run release`는 커밋/푸시 전에 `npm run test-storybook`을 반드시 실행합니다.
 - 두 명령 중 하나라도 실패하면 버전 업데이트, 커밋, 푸시를 진행하지 않습니다.
-- GitHub Actions의 Chromatic workflow는 실패를 허용하지 않으므로, CI에서도 Storybook/Chromatic 실패가 명확히 실패로 남습니다.
-- 긴급 상황에서 `git push --no-verify`로 로컬 hook을 우회하더라도 release 스크립트와 CI 게이트는 우회하지 않는 것을 원칙으로 합니다.
+- GitHub Actions의 Chromatic publish workflow는 무료 한도 소진으로 인한 외부 `UI Tests` pending을 피하기 위해 수동 실행 전용입니다.
+- 긴급 상황에서 `git push --no-verify`로 로컬 hook을 우회하더라도 release 스크립트와 Public Readiness CI 게이트는 우회하지 않는 것을 원칙으로 합니다.
 
 ## 현재 포함된 스토리
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/public-readiness.test.mts
+++ b/tests/public-readiness.test.mts
@@ -30,6 +30,16 @@ test("public readiness CI workflow gates launch-critical checks", () => {
   }
 });
 
+test("Chromatic Storybook publish stays manual-only while free quota is exhausted", () => {
+  const workflow = readRepoFile(".github/workflows/storybook.yml");
+
+  assert.match(workflow, /name: Publish Storybook/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /chromaui\/action@latest/);
+  assert.doesNotMatch(workflow, /^\s+push:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s+pull_request:\s*$/m);
+});
+
 test("playwright config can use the CI-hosted Chrome channel", () => {
   const config = readRepoFile("playwright.config.ts");
 


### PR DESCRIPTION
## Summary
- Chromatic 무료 한도 소진으로 붙는 외부 UI Tests pending을 피하기 위해 Publish Storybook workflow를 수동 실행 전용으로 변경합니다.
- Storybook 로컬 build/test release gate는 유지하고, 관련 문서를 최신 운영 방식에 맞춥니다.
- main branch protection에서 Storybook 필수 체크를 제거했고, 원격 workflow도 disabled_manually 상태로 전환했습니다.

## Related Issue
Refs #55

## Branch Flow
ci/disable-chromatic-storybook -> dev -> main

## Changes
- .github/workflows/storybook.yml의 push/pull_request 자동 트리거 제거
- README 및 docs/testing/storybook.md 운영 문구 갱신
- public readiness 테스트에 Chromatic 수동 전용 정책 회귀 검사 추가

## Test Plan
- node --test tests/public-readiness.test.mts
- npm run lint
- npm run build-storybook
- npm run test-storybook

## Checklist
- [x] Chromatic 자동 실행 비활성화
- [x] Storybook 로컬 검증 유지
- [x] 문서 갱신
- [x] 원격 branch protection 필수 체크 정리