### PR TITLE
feat: SSAFY Verify API 추적 로그 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssartnership",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssartnership",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@supabase/supabase-js": "^2.99.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssartnership",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/app/admin/(protected)/_actions/member-actions.ts
+++ b/src/app/admin/(protected)/_actions/member-actions.ts
@@ -8,10 +8,10 @@ import {
 } from "@/lib/mm-member-sync";
 import {
   parseManualMemberAddInputList,
-  provisionManualMembers,
   type ManualMemberAddFormState,
   type ManualMemberAddYear,
 } from "@/lib/member-manual-add";
+import { provisionManualMembers } from "@/lib/member-manual-add/provision";
 import {
   parseMemberYearValue,
   validateMemberYear,

--- a/src/app/api/ssafy/reset-password/route.ts
+++ b/src/app/api/ssafy/reset-password/route.ts
@@ -26,6 +26,7 @@ import {
   resolveSsafyVerifyAllowedRedirectUris,
 } from "@/lib/ssafy-verify/redirect";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 
 export const runtime = "nodejs";
 
@@ -35,6 +36,14 @@ function publicError(errorCode: string, requestId: string | null, status = 400) 
 
 export async function POST(request: Request) {
   const context = getRequestLogContext(request);
+  const tokenTrace = createSsafyVerifyApiTraceLogger({
+    ...context,
+    actorType: "guest",
+    properties: {
+      flow: "member_password_reset_verify",
+      route: "/api/ssafy/reset-password",
+    },
+  });
   const throttleContext = {
     ipAddress: context.ipAddress ?? null,
     accountIdentifier: null,
@@ -64,6 +73,13 @@ export async function POST(request: Request) {
     const config = getSsafyVerifyServerConfig();
     const rawBody = await readJson(request);
     if (!rawBody.ok) {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_password_reset_ssafy",
+        status: "failure",
+        actorType: "guest",
+        properties: { reason: "invalid_json" },
+      });
       await recordMemberAuthAttempt("ssafy-reset-password", throttleContext, false);
       await delayMemberAuthAttempt("ssafy-reset-password");
       return publicError("INVALID_REQUEST", null, 400);
@@ -90,7 +106,9 @@ export async function POST(request: Request) {
       return publicError(parsedBody.errorCode, null, 400);
     }
 
-    const exchanged = await exchangeSsafyVerificationCode(parsedBody.data, config);
+    const exchanged = await exchangeSsafyVerificationCode(parsedBody.data, config, {
+      trace: tokenTrace,
+    });
     if (!exchanged.ok) {
       await logAuthSecurity({
         ...context,

--- a/src/app/api/ssafy/signup/route.ts
+++ b/src/app/api/ssafy/signup/route.ts
@@ -32,6 +32,13 @@ export async function POST(request: Request) {
   const context = getRequestLogContext(request);
   const signupSession = await getSsafySignupSession();
   if (!signupSession) {
+    await logAuthSecurity({
+      ...context,
+      eventName: "member_signup_complete",
+      status: "failure",
+      actorType: "guest",
+      properties: { reason: "signup_session_expired" },
+    });
     return errorResponse("signup_session_expired", 401);
   }
 
@@ -39,6 +46,17 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => null);
     const parsed = parseSsafySignupCompleteInput(body);
     if (!parsed.ok) {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_signup_complete",
+        status: "failure",
+        actorType: "guest",
+        identifier: signupSession.sub,
+        properties: {
+          reason: "invalid_request",
+          fieldNames: Object.keys(parsed.fieldErrors),
+        },
+      });
       return errorResponse("invalid_request", 400, {
         fieldErrors: parsed.fieldErrors,
       });
@@ -54,6 +72,17 @@ export async function POST(request: Request) {
       marketingPolicy,
     );
     if (policyError) {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_signup_complete",
+        status: "failure",
+        actorType: "guest",
+        identifier: signupSession.sub,
+        properties: {
+          reason: "policy_outdated",
+          message: policyError,
+        },
+      });
       return errorResponse("policy_outdated", 409, { message: policyError });
     }
 
@@ -63,12 +92,35 @@ export async function POST(request: Request) {
       mattermostUserId: signupSession.mattermostUserId,
     });
     if (duplicate.ok || duplicate.errorCode === "SSAFY_MEMBER_CONFLICT") {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_signup_complete",
+        status: "blocked",
+        actorType: duplicate.ok ? "member" : "guest",
+        actorId: duplicate.ok ? duplicate.member.id : null,
+        identifier: signupSession.sub,
+        properties: {
+          reason: duplicate.ok ? "already_registered" : duplicate.errorCode,
+          mattermostUserId: signupSession.mattermostUserId,
+        },
+      });
       await clearSsafySignupSession();
       return errorResponse("already_registered", 409, {
         redirectTo: "/auth/login",
       });
     }
     if (duplicate.errorCode === "MEMBER_LOOKUP_FAILED") {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_signup_complete",
+        status: "failure",
+        actorType: "guest",
+        identifier: signupSession.sub,
+        properties: {
+          reason: "signup_lookup_failed",
+          mattermostUserId: signupSession.mattermostUserId,
+        },
+      });
       return errorResponse("signup_lookup_failed", 503);
     }
 

--- a/src/app/api/ssafy/verify-token/route.ts
+++ b/src/app/api/ssafy/verify-token/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { getRequestLogContext, logAuthSecurity } from "@/lib/activity-logs";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import {
   delayMemberAuthAttempt,
   getMemberAuthAttemptScope,
@@ -49,6 +50,14 @@ function shouldExposeSsafyVerifyDebug() {
 
 export async function POST(request: Request) {
   const context = getRequestLogContext(request);
+  const tokenTrace = createSsafyVerifyApiTraceLogger({
+    ...context,
+    actorType: "guest",
+    properties: {
+      flow: "member_signup_verify",
+      route: "/api/ssafy/verify-token",
+    },
+  });
   const throttleContext = {
     ipAddress: context.ipAddress ?? null,
     accountIdentifier: null,
@@ -78,6 +87,13 @@ export async function POST(request: Request) {
     const config = getSsafyVerifyServerConfig();
     const rawBody = await readJson(request);
     if (!rawBody.ok) {
+      await logAuthSecurity({
+        ...context,
+        eventName: "member_ssafy_verify",
+        status: "failure",
+        actorType: "guest",
+        properties: { reason: "invalid_json" },
+      });
       await recordMemberAuthAttempt("ssafy-verify", throttleContext, false);
       await delayMemberAuthAttempt("ssafy-verify");
       return publicError("INVALID_REQUEST", null, 400);
@@ -104,7 +120,9 @@ export async function POST(request: Request) {
       return publicError(parsedBody.errorCode, null, 400);
     }
 
-    const exchanged = await exchangeSsafyVerificationCode(parsedBody.data, config);
+    const exchanged = await exchangeSsafyVerificationCode(parsedBody.data, config, {
+      trace: tokenTrace,
+    });
     if (!exchanged.ok) {
       await logAuthSecurity({
         ...context,
@@ -211,6 +229,18 @@ export async function POST(request: Request) {
       claims: verified.claims,
       verificationId: exchanged.verificationId,
       scope: exchanged.scope,
+      trace: createSsafyVerifyApiTraceLogger({
+        ...context,
+        actorType: "guest",
+        identifier: verified.claims.sub,
+        properties: {
+          flow: "member_signup_profile",
+          route: "/api/ssafy/verify-token",
+          verificationId: exchanged.verificationId,
+          grantedScope: exchanged.scope,
+          hasMattermostUserId: Boolean(verified.claims.mattermostUserId),
+        },
+      }),
     });
     if (!signupProfile.ok) {
       const debug = shouldExposeSsafyVerifyDebug()

--- a/src/components/admin/logs/utils.ts
+++ b/src/components/admin/logs/utils.ts
@@ -81,6 +81,8 @@ const securityLabels: Record<string, string> = {
   member_login: '회원 로그인',
   member_logout: '회원 로그아웃',
   member_signup_complete: '회원가입 완료',
+  member_ssafy_verify: '회원가입 SSAFY 인증',
+  ssafy_verify_api_trace: 'SSAFY Verify API 추적',
   member_policy_consent: '약관 동의',
   member_password_reset_ssafy: '비밀번호 재설정 SSAFY 인증',
   member_password_reset_complete: '비밀번호 재설정 완료',

--- a/src/lib/admin-notification-ops-delivery.ts
+++ b/src/lib/admin-notification-ops-delivery.ts
@@ -3,6 +3,7 @@ import { buildNotificationPayload } from "@/lib/push/payloads";
 import {
   getSsafyVerifyServerApiConfig,
 } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import {
   SsafyVerifyServerApiError,
   createSsafyVerifyServerApiClient,
@@ -119,7 +120,18 @@ async function sendMattermostCampaignDeliveriesViaVerify(params: {
   url?: string | null;
   members: AudienceMember[];
 }): Promise<ChannelDeliveryResult> {
-  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+    trace: createSsafyVerifyApiTraceLogger({
+      actorType: "system",
+      identifier: params.notificationId,
+      properties: {
+        flow: "admin_notification_mattermost_delivery",
+        notificationId: params.notificationId,
+        notificationType: params.notificationType,
+        targetCount: params.members.length,
+      },
+    }),
+  });
   let sent = 0;
   let failed = 0;
   let skipped = 0;

--- a/src/lib/event-catalog.ts
+++ b/src/lib/event-catalog.ts
@@ -91,6 +91,7 @@ export const AUTH_SECURITY_EVENT_NAMES = [
   'member_logout',
   'member_signup_complete',
   'member_ssafy_verify',
+  'ssafy_verify_api_trace',
   'member_policy_consent',
   'member_password_reset_ssafy',
   'member_password_reset_complete',

--- a/src/lib/member-manual-add.ts
+++ b/src/lib/member-manual-add.ts
@@ -10,4 +10,3 @@ export {
   type ManualMemberAddItemStatus,
   type ManualMemberAddYear,
 } from "./member-manual-add/shared";
-export { provisionManualMembers } from "./member-manual-add/provision";

--- a/src/lib/member-manual-add/lookup.ts
+++ b/src/lib/member-manual-add/lookup.ts
@@ -1,5 +1,6 @@
 import type { MemberRow } from "@/lib/mm-member-sync";
 import { getSsafyVerifyServerApiConfig } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import { createSsafyVerifyServerApiClient } from "@/lib/ssafy-verify/server-api";
 import {
   extractSsafyVerifyMemberProfiles,
@@ -68,7 +69,18 @@ export async function resolveManualMemberResolution(
   for (const year of yearsToTry) {
     try {
       await getSenderSession(year, cache);
-      const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+      const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+        trace: createSsafyVerifyApiTraceLogger({
+          actorType: "system",
+          identifier: username,
+          properties: {
+            flow: "manual_member_add_lookup",
+            username,
+            requestedYear,
+            lookupYear: year,
+          },
+        }),
+      });
       const payload = await client.findMattermostUsers({
         username,
         cohort: year,

--- a/src/lib/member-manual-add/provision.ts
+++ b/src/lib/member-manual-add/provision.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { generateTempPassword, hashPassword } from "@/lib/password";
 import { getSsafyVerifyServerApiConfig } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import { createSsafyVerifyServerApiClient } from "@/lib/ssafy-verify/server-api";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import { validateMmUsername } from "@/lib/validation";
@@ -55,7 +56,15 @@ export async function provisionManualMembers(
   inputs: ManualMemberAddInput[],
 ): Promise<ManualMemberAddBatchResult> {
   const supabase = getSupabaseAdminClient();
-  const verifyClient = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+  const verifyClient = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+    trace: createSsafyVerifyApiTraceLogger({
+      actorType: "system",
+      properties: {
+        flow: "manual_member_temp_password_notification",
+        requestedYear,
+      },
+    }),
+  });
   const senderSessionCache = new Map<number, Promise<SenderSession>>();
   const items: ManualMemberAddItem[] = [];
   let success = 0;

--- a/src/lib/mm-directory/collector.ts
+++ b/src/lib/mm-directory/collector.ts
@@ -3,6 +3,7 @@ import { mergeDirectorySnapshot } from "./shared";
 import {
   getSsafyVerifyServerApiConfig,
 } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import { createSsafyVerifyServerApiClient } from "@/lib/ssafy-verify/server-api";
 import {
   extractSsafyVerifyMemberProfiles,
@@ -27,7 +28,14 @@ function createSnapshotBatch(): SelectableYearSnapshotBatch {
 }
 
 async function getVerifyProfileEventSnapshots(): Promise<SelectableYearSnapshotBatch> {
-  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+    trace: createSsafyVerifyApiTraceLogger({
+      actorType: "system",
+      properties: {
+        flow: "profile_events_directory_sync",
+      },
+    }),
+  });
   const snapshots = new Map<string, MmUserDirectorySnapshot>();
   const failures: MmUserDirectorySyncResult["failures"] = [];
   let checked = 0;

--- a/src/lib/mm-member-sync/snapshot.ts
+++ b/src/lib/mm-member-sync/snapshot.ts
@@ -11,6 +11,7 @@ import {
   wrapMmMemberSyncDbError,
 } from "./shared";
 import { getSsafyVerifyServerApiConfig } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import {
   SsafyVerifyServerApiError,
   createSsafyVerifyServerApiClient,
@@ -48,7 +49,16 @@ export async function getSenderSessionForYear(
 export async function fetchMemberSnapshotByUserId(
   userId: string,
 ): Promise<MemberSyncSnapshot | null> {
-  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+    trace: createSsafyVerifyApiTraceLogger({
+      actorType: "system",
+      identifier: userId,
+      properties: {
+        flow: "member_profile_sync",
+        mattermostUserId: userId,
+      },
+    }),
+  });
   const payload = await client.getMattermostUserProfile(userId).catch((error) => {
     if (error instanceof SsafyVerifyServerApiError && error.status === 404) {
       return null;

--- a/src/lib/ssafy-verify/api-trace.ts
+++ b/src/lib/ssafy-verify/api-trace.ts
@@ -1,0 +1,284 @@
+import type { EventActorType } from "@/lib/event-catalog";
+
+type UnknownRecord = Record<string, unknown>;
+
+export type SsafyVerifyTraceSource = "server-api" | "user-auth";
+
+export type SsafyVerifyTraceRequestSummary = Record<string, unknown>;
+
+export type SsafyVerifyTraceResponseSummary = {
+  keys: string[];
+  dataKeys: string[];
+  errorKeys: string[];
+  profileKeys: string[];
+  resultsCount: number | null;
+  targetsCount: number | null;
+  requestId: string | null;
+  errorCode: string | null;
+  status: string | null;
+  campaignId: string | null;
+  notificationId: string | null;
+  hasAccessToken: boolean;
+  hasVerificationToken: boolean;
+  tokenType: string | null;
+  scope: string | null;
+  expiresIn: number | null;
+  verificationId: string | null;
+};
+
+export type SsafyVerifyApiTraceEvent = {
+  source: SsafyVerifyTraceSource;
+  operation: string;
+  method: string;
+  path: string;
+  scopes: readonly string[];
+  startedAt: string;
+  durationMs: number;
+  status: number | null;
+  ok: boolean;
+  request: SsafyVerifyTraceRequestSummary;
+  response: SsafyVerifyTraceResponseSummary | null;
+  errorCode: string | null;
+  providerRequestId: string | null;
+};
+
+export type SsafyVerifyApiTraceHandler = (
+  event: SsafyVerifyApiTraceEvent,
+) => void | Promise<void>;
+
+type TraceBaseLogContext = {
+  path?: string | null;
+  referrer?: string | null;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+  host?: string | null;
+};
+
+type TraceLoggerInput = TraceBaseLogContext & {
+  actorType?: EventActorType;
+  actorId?: string | null;
+  identifier?: string | null;
+  properties?: Record<string, unknown> | null;
+};
+
+const SAFE_CODE_PATTERN = /^[A-Z0-9_]{1,96}$/;
+const SAFE_REQUEST_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,120}$/;
+const MAX_KEYS = 40;
+const MAX_TARGET_IDENTIFIERS = 25;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeKeys(value: unknown) {
+  return isRecord(value) ? Object.keys(value).sort().slice(0, MAX_KEYS) : [];
+}
+
+function readRecord(value: unknown, key: string) {
+  return isRecord(value) && isRecord(value[key]) ? value[key] : null;
+}
+
+function readString(record: unknown, keys: readonly string[]) {
+  if (!isRecord(record)) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().slice(0, 300);
+    }
+  }
+  return null;
+}
+
+function readSafeCode(record: unknown, keys: readonly string[]) {
+  const value = readString(record, keys);
+  return value && SAFE_CODE_PATTERN.test(value) ? value : null;
+}
+
+function readSafeRequestId(record: unknown, keys: readonly string[]) {
+  const value = readString(record, keys);
+  return value && SAFE_REQUEST_ID_PATTERN.test(value) ? value : null;
+}
+
+function readInteger(record: unknown, key: string) {
+  if (!isRecord(record)) {
+    return null;
+  }
+  const value = record[key];
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function readLength(record: unknown, key: string) {
+  if (!isRecord(record)) {
+    return null;
+  }
+  const value = record[key];
+  return Array.isArray(value) ? value.length : null;
+}
+
+function summarizeTarget(target: unknown) {
+  if (!isRecord(target)) {
+    return null;
+  }
+  return {
+    sub: readString(target, ["sub"]),
+    mattermostUserId: readString(target, [
+      "ssafy_mattermost_user_id",
+      "mattermost_user_id",
+      "mattermostUserId",
+    ]),
+    username: readString(target, ["username"]),
+    cohort: readString(target, ["cohort"]),
+  };
+}
+
+function summarizeTargetIdentifiersFromTargets(targets: unknown) {
+  if (!Array.isArray(targets)) {
+    return [];
+  }
+  return targets
+    .map((item) => {
+      const record = isRecord(item) ? item : {};
+      return summarizeTarget(record.target);
+    })
+    .filter((item): item is NonNullable<ReturnType<typeof summarizeTarget>> => Boolean(item))
+    .slice(0, MAX_TARGET_IDENTIFIERS);
+}
+
+export function summarizeSsafyVerifyFormTraceRequest(
+  body: URLSearchParams | string,
+) {
+  const params =
+    typeof body === "string" ? new URLSearchParams(body) : body;
+  return {
+    contentType: "application/x-www-form-urlencoded",
+    fields: Array.from(params.keys()),
+    grantType: params.get("grant_type"),
+    clientId: params.get("client_id"),
+    hasClientSecret: params.has("client_secret"),
+    hasCode: params.has("code"),
+    hasCodeVerifier: params.has("code_verifier"),
+    scope: params.get("scope"),
+  };
+}
+
+export function summarizeSsafyVerifyJsonTraceRequest(
+  body: unknown,
+  query?: URLSearchParams,
+) {
+  if (!isRecord(body)) {
+    return {
+      contentType: body === undefined ? null : "application/json",
+      queryKeys: query ? Array.from(query.keys()).sort() : [],
+      query: query ? Object.fromEntries(query.entries()) : {},
+    };
+  }
+
+  const template = readRecord(body, "template");
+  const variables = readRecord(template, "variables");
+  const targets = body.targets;
+  return {
+    contentType: "application/json",
+    keys: safeKeys(body),
+    queryKeys: query ? Array.from(query.keys()).sort() : [],
+    query: query ? Object.fromEntries(query.entries()) : {},
+    idempotencyKey: readString(body, ["idempotency_key", "idempotencyKey"]),
+    campaignId: readString(body, ["campaign_id", "campaignId"]),
+    purpose: readString(body, ["purpose"]),
+    templateId: readString(template, ["id", "template_id", "templateId"]),
+    variableKeys: safeKeys(variables),
+    target: summarizeTarget(body.target),
+    targetsCount: Array.isArray(targets) ? targets.length : null,
+    targetIdentifiers: summarizeTargetIdentifiersFromTargets(targets),
+  };
+}
+
+export function summarizeSsafyVerifyTraceResponsePayload(
+  payload: unknown,
+): SsafyVerifyTraceResponseSummary {
+  const root = isRecord(payload) ? payload : {};
+  const data = readRecord(root, "data");
+  const record = data ?? root;
+  const error = readRecord(root, "error") ?? readRecord(record, "error");
+  const profile = readRecord(record, "profile");
+  const result = readRecord(root, "result") ?? readRecord(record, "result");
+
+  return {
+    keys: safeKeys(root),
+    dataKeys: safeKeys(data),
+    errorKeys: safeKeys(error),
+    profileKeys: safeKeys(profile),
+    resultsCount: readLength(record, "results"),
+    targetsCount: readLength(record, "targets"),
+    requestId:
+      readSafeRequestId(root, ["request_id", "requestId"]) ??
+      readSafeRequestId(record, ["request_id", "requestId"]) ??
+      readSafeRequestId(error, ["request_id", "requestId"]),
+    errorCode:
+      readSafeCode(root, ["error_code", "errorCode"]) ??
+      readSafeCode(record, ["error_code", "errorCode"]) ??
+      readSafeCode(error, ["code", "error_code", "errorCode"]),
+    status: readString(record, ["status"]),
+    campaignId: readString(record, ["campaign_id", "campaignId"]),
+    notificationId: readString(record, ["notification_id", "notificationId"]),
+    hasAccessToken: typeof root.access_token === "string",
+    hasVerificationToken: typeof root.verification_token === "string",
+    tokenType: readString(root, ["token_type", "tokenType"]),
+    scope: readString(root, ["scope"]),
+    expiresIn: readInteger(root, "expires_in"),
+    verificationId: readString(result, ["verification_id", "verificationId"]),
+  };
+}
+
+export async function emitSsafyVerifyApiTrace(
+  handler: SsafyVerifyApiTraceHandler | null | undefined,
+  event: SsafyVerifyApiTraceEvent,
+) {
+  if (!handler) {
+    return;
+  }
+  try {
+    await handler(event);
+  } catch (error) {
+    console.error("[ssafy-verify-api-trace] log failed", error);
+  }
+}
+
+export function createSsafyVerifyApiTraceLogger(input: TraceLoggerInput = {}) {
+  return async (event: SsafyVerifyApiTraceEvent) => {
+    const { logAuthSecurity } = await import("@/lib/activity-logs");
+    await logAuthSecurity({
+      path: input.path ?? null,
+      referrer: input.referrer ?? null,
+      userAgent: input.userAgent ?? null,
+      ipAddress: input.ipAddress ?? null,
+      host: input.host ?? null,
+      eventName: "ssafy_verify_api_trace",
+      status: event.ok ? "success" : "failure",
+      actorType: input.actorType ?? "system",
+      actorId: input.actorId ?? null,
+      identifier:
+        input.identifier ??
+        event.providerRequestId ??
+        event.response?.requestId ??
+        null,
+      properties: {
+        ...(input.properties ?? {}),
+        source: event.source,
+        operation: event.operation,
+        method: event.method,
+        path: event.path,
+        scopes: event.scopes,
+        startedAt: event.startedAt,
+        durationMs: event.durationMs,
+        status: event.status,
+        ok: event.ok,
+        request: event.request,
+        response: event.response,
+        errorCode: event.errorCode,
+        providerRequestId: event.providerRequestId,
+      },
+    });
+  };
+}

--- a/src/lib/ssafy-verify/directory.ts
+++ b/src/lib/ssafy-verify/directory.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/ssafy-cycle-settings";
 import type { SelectableStudentMatch } from "@/lib/mattermost/types";
 import { getSsafyVerifyServerApiConfig } from "@/lib/ssafy-verify/config";
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
 import {
   createSsafyVerifyServerApiClient,
 } from "@/lib/ssafy-verify/server-api";
@@ -21,7 +22,16 @@ export async function resolveSelectableMemberByUsername(
   const studentYears = getConfiguredSelectableSsafyYears(cycleSettings).sort(
     (a, b) => b - a,
   );
-  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig());
+  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+    trace: createSsafyVerifyApiTraceLogger({
+      actorType: "system",
+      identifier: safeUsername,
+      properties: {
+        flow: "selectable_member_directory_lookup",
+        username: safeUsername,
+      },
+    }),
+  });
   const searchPlans = [
     { years: studentYears, expectStaff: false },
     { years: [15, 14], expectStaff: true },

--- a/src/lib/ssafy-verify/server-api.ts
+++ b/src/lib/ssafy-verify/server-api.ts
@@ -1,4 +1,12 @@
 import type { SsafyVerifyServerApiConfig } from "./config";
+import {
+  emitSsafyVerifyApiTrace,
+  summarizeSsafyVerifyFormTraceRequest,
+  summarizeSsafyVerifyJsonTraceRequest,
+  summarizeSsafyVerifyTraceResponsePayload,
+  type SsafyVerifyApiTraceHandler,
+  type SsafyVerifyTraceRequestSummary,
+} from "./api-trace";
 
 export const SSAFY_VERIFY_SERVER_API_SCOPES = {
   profileRead: "ssafy.profile.read",
@@ -77,6 +85,7 @@ export type SsafyVerifyServerApiClient = ReturnType<
 type ClientOptions = {
   fetch?: typeof fetch;
   now?: () => number;
+  trace?: SsafyVerifyApiTraceHandler | null;
 };
 
 type CachedToken = {
@@ -417,35 +426,109 @@ export function createSsafyVerifyServerApiClient(
 ) {
   const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
   const now = options.now ?? (() => Date.now());
+  const trace = options.trace ?? null;
   const tokenCache = new Map<string, CachedToken>();
 
   async function fetchJson(
     url: string,
     init: RequestInit,
     fallback: { status: number; errorCode: string; message: string },
+    traceInput: {
+      operation: string;
+      method: "GET" | "POST";
+      path: string;
+      scopes: readonly string[];
+      request: SsafyVerifyTraceRequestSummary;
+    },
   ) {
+    const startedAtMs = now();
     const response = await fetchImpl(url, init).then(
       (value) => value,
       () => null,
     );
     if (!response) {
+      await emitSsafyVerifyApiTrace(trace, {
+        source: "server-api",
+        operation: traceInput.operation,
+        method: traceInput.method,
+        path: traceInput.path,
+        scopes: traceInput.scopes,
+        startedAt: new Date(startedAtMs).toISOString(),
+        durationMs: Math.max(0, now() - startedAtMs),
+        status: null,
+        ok: false,
+        request: traceInput.request,
+        response: null,
+        errorCode: fallback.errorCode,
+        providerRequestId: null,
+      });
       throw new SsafyVerifyServerApiError(fallback);
     }
 
     const json = await readJson(response);
+    const responseSummary = json.ok
+      ? summarizeSsafyVerifyTraceResponsePayload(json.value)
+      : null;
     if (!response.ok) {
-      throw normalizeErrorPayload(json.ok ? json.value : null, {
+      const normalizedError = normalizeErrorPayload(json.ok ? json.value : null, {
         ...fallback,
         status: response.status,
       });
+      await emitSsafyVerifyApiTrace(trace, {
+        source: "server-api",
+        operation: traceInput.operation,
+        method: traceInput.method,
+        path: traceInput.path,
+        scopes: traceInput.scopes,
+        startedAt: new Date(startedAtMs).toISOString(),
+        durationMs: Math.max(0, now() - startedAtMs),
+        status: response.status,
+        ok: false,
+        request: traceInput.request,
+        response: responseSummary,
+        errorCode: normalizedError.errorCode,
+        providerRequestId: normalizedError.requestId,
+      });
+      throw normalizedError;
     }
     if (!json.ok) {
+      await emitSsafyVerifyApiTrace(trace, {
+        source: "server-api",
+        operation: traceInput.operation,
+        method: traceInput.method,
+        path: traceInput.path,
+        scopes: traceInput.scopes,
+        startedAt: new Date(startedAtMs).toISOString(),
+        durationMs: Math.max(0, now() - startedAtMs),
+        status: response.status,
+        ok: false,
+        request: traceInput.request,
+        response: null,
+        errorCode: "VERIFY_SERVER_API_INVALID_RESPONSE",
+        providerRequestId: null,
+      });
       throw new SsafyVerifyServerApiError({
         status: 502,
         errorCode: "VERIFY_SERVER_API_INVALID_RESPONSE",
         message: "SSAFY Verify Server API 응답을 확인하지 못했습니다.",
       });
     }
+
+    await emitSsafyVerifyApiTrace(trace, {
+      source: "server-api",
+      operation: traceInput.operation,
+      method: traceInput.method,
+      path: traceInput.path,
+      scopes: traceInput.scopes,
+      startedAt: new Date(startedAtMs).toISOString(),
+      durationMs: Math.max(0, now() - startedAtMs),
+      status: response.status,
+      ok: true,
+      request: traceInput.request,
+      response: responseSummary,
+      errorCode: null,
+      providerRequestId: responseSummary?.requestId ?? null,
+    });
 
     return json.value;
   }
@@ -481,6 +564,13 @@ export function createSsafyVerifyServerApiClient(
         status: 502,
         errorCode: "VERIFY_SERVER_TOKEN_FAILED",
         message: "SSAFY Verify Server API 토큰 발급에 실패했습니다.",
+      },
+      {
+        operation: "client_credentials_token",
+        method: "POST",
+        path: "/server/token",
+        scopes: scope ? scope.split(" ") : [],
+        request: summarizeSsafyVerifyFormTraceRequest(body),
       },
     );
 
@@ -547,6 +637,16 @@ export function createSsafyVerifyServerApiClient(
         status: 502,
         errorCode: "VERIFY_SERVER_API_FAILED",
         message: "SSAFY Verify Server API 요청에 실패했습니다.",
+      },
+      {
+        operation: "server_api_request",
+        method: input.method,
+        path: input.path,
+        scopes: input.scopes,
+        request: summarizeSsafyVerifyJsonTraceRequest(
+          input.body,
+          input.query,
+        ),
       },
     );
   }

--- a/src/lib/ssafy-verify/signup-profile.ts
+++ b/src/lib/ssafy-verify/signup-profile.ts
@@ -5,6 +5,7 @@ import {
   createSsafyVerifyServerApiClient,
   SsafyVerifyServerApiError,
 } from "./server-api";
+import type { SsafyVerifyApiTraceHandler } from "./api-trace";
 import { extractSsafyVerifyMemberProfiles } from "./profile";
 import type { SsafySignupSessionData } from "./signup";
 
@@ -84,12 +85,14 @@ export async function resolveSsafySignupProfile(input: {
   claims: SsafyVerificationClaims;
   verificationId: string | null;
   scope: string | null;
+  trace?: SsafyVerifyApiTraceHandler | null;
 }): Promise<SsafySignupProfileResult> {
   const lookup = input.claims.mattermostUserId ? "mattermost_user_id" : "sub";
 
   try {
     const client = createSsafyVerifyServerApiClient(
       getSsafyVerifyServerApiConfig(),
+      { trace: input.trace ?? null },
     );
     const payload = input.claims.mattermostUserId
       ? await client.getMattermostUserProfile(input.claims.mattermostUserId)

--- a/src/lib/ssafy-verify/token.ts
+++ b/src/lib/ssafy-verify/token.ts
@@ -3,6 +3,18 @@ import { z } from "zod";
 import { validateSsafyVerificationClaims } from "./claims";
 import type { SsafyVerifyCallbackBody } from "./schema";
 import type { SsafyVerifyServerConfig } from "./config";
+import {
+  emitSsafyVerifyApiTrace,
+  summarizeSsafyVerifyFormTraceRequest,
+  summarizeSsafyVerifyTraceResponsePayload,
+  type SsafyVerifyApiTraceHandler,
+} from "./api-trace";
+
+type ExchangeOptions = {
+  fetch?: typeof fetch;
+  now?: () => number;
+  trace?: SsafyVerifyApiTraceHandler | null;
+};
 
 const jwksByIssuer = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
@@ -50,7 +62,11 @@ async function readResponseJson(response: Response) {
 export async function exchangeSsafyVerificationCode(
   body: SsafyVerifyCallbackBody,
   config: SsafyVerifyServerConfig,
+  options: ExchangeOptions = {},
 ) {
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+  const now = options.now ?? (() => Date.now());
+  const trace = options.trace ?? null;
   const params = new URLSearchParams({
     grant_type: "verification_code",
     client_id: config.clientId,
@@ -62,7 +78,9 @@ export async function exchangeSsafyVerificationCode(
     params.set("client_secret", config.clientSecret);
   }
 
-  const tokenResponse = await fetch(`${config.issuer}/verify/token`, {
+  const startedAtMs = now();
+  const traceRequest = summarizeSsafyVerifyFormTraceRequest(params);
+  const tokenResponse = await fetchImpl(`${config.issuer}/verify/token`, {
     method: "POST",
     headers: {
       "cache-control": "no-store",
@@ -73,6 +91,21 @@ export async function exchangeSsafyVerificationCode(
   }).then((response) => response, () => null);
 
   if (!tokenResponse) {
+    await emitSsafyVerifyApiTrace(trace, {
+      source: "user-auth",
+      operation: "verification_code_exchange",
+      method: "POST",
+      path: "/verify/token",
+      scopes: [],
+      startedAt: new Date(startedAtMs).toISOString(),
+      durationMs: Math.max(0, now() - startedAtMs),
+      status: null,
+      ok: false,
+      request: traceRequest,
+      response: null,
+      errorCode: "VERIFY_TOKEN_FAILED",
+      providerRequestId: null,
+    });
     return {
       ok: false as const,
       errorCode: "VERIFY_TOKEN_FAILED",
@@ -83,6 +116,21 @@ export async function exchangeSsafyVerificationCode(
 
   const tokenJson = await readResponseJson(tokenResponse);
   if (!tokenJson.ok) {
+    await emitSsafyVerifyApiTrace(trace, {
+      source: "user-auth",
+      operation: "verification_code_exchange",
+      method: "POST",
+      path: "/verify/token",
+      scopes: [],
+      startedAt: new Date(startedAtMs).toISOString(),
+      durationMs: Math.max(0, now() - startedAtMs),
+      status: tokenResponse.status,
+      ok: false,
+      request: traceRequest,
+      response: null,
+      errorCode: "VERIFY_TOKEN_FAILED",
+      providerRequestId: null,
+    });
     return {
       ok: false as const,
       errorCode: "VERIFY_TOKEN_FAILED",
@@ -91,22 +139,55 @@ export async function exchangeSsafyVerificationCode(
     };
   }
 
+  const responseSummary = summarizeSsafyVerifyTraceResponsePayload(tokenJson.value);
   if (!tokenResponse.ok) {
     const errorPayload = tokenErrorSchema.safeParse(tokenJson.value);
+    const errorCode = errorPayload.success
+      ? errorPayload.data.error?.code ?? "VERIFY_TOKEN_FAILED"
+      : "VERIFY_TOKEN_FAILED";
+    const requestId = errorPayload.success
+      ? errorPayload.data.error?.request_id ?? null
+      : null;
+    await emitSsafyVerifyApiTrace(trace, {
+      source: "user-auth",
+      operation: "verification_code_exchange",
+      method: "POST",
+      path: "/verify/token",
+      scopes: [],
+      startedAt: new Date(startedAtMs).toISOString(),
+      durationMs: Math.max(0, now() - startedAtMs),
+      status: tokenResponse.status,
+      ok: false,
+      request: traceRequest,
+      response: responseSummary,
+      errorCode,
+      providerRequestId: requestId,
+    });
     return {
       ok: false as const,
-      errorCode: errorPayload.success
-        ? errorPayload.data.error?.code ?? "VERIFY_TOKEN_FAILED"
-        : "VERIFY_TOKEN_FAILED",
-      requestId: errorPayload.success
-        ? errorPayload.data.error?.request_id ?? null
-        : null,
+      errorCode,
+      requestId,
       status: tokenResponse.status,
     };
   }
 
   const tokenPayload = tokenSuccessSchema.safeParse(tokenJson.value);
   if (!tokenPayload.success) {
+    await emitSsafyVerifyApiTrace(trace, {
+      source: "user-auth",
+      operation: "verification_code_exchange",
+      method: "POST",
+      path: "/verify/token",
+      scopes: [],
+      startedAt: new Date(startedAtMs).toISOString(),
+      durationMs: Math.max(0, now() - startedAtMs),
+      status: 502,
+      ok: false,
+      request: traceRequest,
+      response: responseSummary,
+      errorCode: "VERIFY_TOKEN_FAILED",
+      providerRequestId: responseSummary.requestId,
+    });
     return {
       ok: false as const,
       errorCode: "VERIFY_TOKEN_FAILED",
@@ -114,6 +195,22 @@ export async function exchangeSsafyVerificationCode(
       status: 502,
     };
   }
+
+  await emitSsafyVerifyApiTrace(trace, {
+    source: "user-auth",
+    operation: "verification_code_exchange",
+    method: "POST",
+    path: "/verify/token",
+    scopes: [],
+    startedAt: new Date(startedAtMs).toISOString(),
+    durationMs: Math.max(0, now() - startedAtMs),
+    status: tokenResponse.status,
+    ok: true,
+    request: traceRequest,
+    response: responseSummary,
+    errorCode: null,
+    providerRequestId: responseSummary.requestId,
+  });
 
   return {
     ok: true as const,

--- a/tests/ssafy-verify-server-api.test.mts
+++ b/tests/ssafy-verify-server-api.test.mts
@@ -374,6 +374,144 @@ test("SSAFY Verify Server API preserves nested profile error request ids", async
   );
 });
 
+test("SSAFY Verify Server API emits redacted request and response traces", async () => {
+  const {
+    createSsafyVerifyServerApiClient,
+  } = await serverApiModulePromise;
+  const traces: unknown[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = String(input);
+    if (url.endsWith("/server/token")) {
+      return jsonResponse({
+        access_token: "access-token-secret",
+        token_type: "Bearer",
+        expires_in: 600,
+        scope: "ssafy.profile.read ssafy.directory.lookup",
+      });
+    }
+
+    assert.equal(
+      new Headers(init?.headers).get("authorization"),
+      "Bearer access-token-secret",
+    );
+    return jsonResponse({
+      ok: true,
+      data: {
+        profile: {
+          sub: "pairwise-subject",
+          mattermost_user_id: "mm.user_123",
+          name: "김싸피",
+        },
+      },
+      request_id: "req-profile-123",
+    });
+  };
+
+  const client = createSsafyVerifyServerApiClient(
+    {
+      issuer: "https://verify.example.com",
+      apiBaseUrl: "https://verify.example.com/v1",
+      clientId: "server-api-client",
+      clientSecret: "server-secret",
+    },
+    {
+      fetch: fetchImpl,
+      now: () => 1_000_000,
+      trace: (event) => {
+        traces.push(event);
+      },
+    },
+  );
+
+  await client.getMattermostUserProfile("mm.user_123");
+
+  assert.equal(traces.length, 2);
+  assert.deepEqual(
+    traces.map((event) => (event as { path: string }).path),
+    ["/server/token", "/mattermost-users/mm.user_123/profile"],
+  );
+  assert.deepEqual(
+    traces.map((event) => (event as { ok: boolean }).ok),
+    [true, true],
+  );
+  assert.equal(
+    (traces[1] as { response: { requestId: string | null } }).response.requestId,
+    "req-profile-123",
+  );
+
+  const serialized = JSON.stringify(traces);
+  assert.equal(serialized.includes("server-secret"), false);
+  assert.equal(serialized.includes("access-token-secret"), false);
+  assert.equal(serialized.includes("authorization"), false);
+  assert.equal(serialized.includes("verification_token"), false);
+});
+
+test("SSAFY Verify Server API failure traces keep provider error without raw payload leaks", async () => {
+  const {
+    createSsafyVerifyServerApiClient,
+  } = await serverApiModulePromise;
+  const traces: unknown[] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    if (String(input).endsWith("/server/token")) {
+      return jsonResponse({
+        access_token: "access-token-secret",
+        token_type: "Bearer",
+        expires_in: 600,
+      });
+    }
+
+    return jsonResponse(
+      {
+        ok: false,
+        error: {
+          code: "PROFILE_NOT_FOUND",
+          message: "프로필을 찾을 수 없습니다.",
+          request_id: "icn1::req-404",
+        },
+        raw_mattermost_response: {
+          opaque: "fixture-mm-sensitive-value",
+          body: "internal raw response",
+        },
+      },
+      404,
+    );
+  };
+
+  const client = createSsafyVerifyServerApiClient(
+    {
+      issuer: "https://verify.example.com",
+      apiBaseUrl: "https://verify.example.com/v1",
+      clientId: "server-api-client",
+      clientSecret: "server-secret",
+    },
+    {
+      fetch: fetchImpl,
+      trace: (event) => {
+        traces.push(event);
+      },
+    },
+  );
+
+  await assert.rejects(() => client.getSsafyMemberProfile("pairwise-subject"));
+
+  const failure = traces.at(-1) as {
+    ok: boolean;
+    status: number | null;
+    errorCode: string | null;
+    providerRequestId: string | null;
+    response: { keys: string[]; errorCode: string | null; requestId: string | null };
+  };
+  assert.equal(failure.ok, false);
+  assert.equal(failure.status, 404);
+  assert.equal(failure.errorCode, "PROFILE_NOT_FOUND");
+  assert.equal(failure.providerRequestId, "icn1::req-404");
+  assert.deepEqual(failure.response.keys, ["error", "ok", "raw_mattermost_response"]);
+
+  const serialized = JSON.stringify(traces);
+  assert.equal(serialized.includes("fixture-mm-sensitive-value"), false);
+  assert.equal(serialized.includes("internal raw response"), false);
+});
+
 test("SSAFY Verify Server API validates Mattermost IDs and batch size", async () => {
   const {
     createSsafyVerifyServerApiClient,

--- a/tests/ssafy-verify-token-trace.test.mts
+++ b/tests/ssafy-verify-token-trace.test.mts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type TokenModule = typeof import("../src/lib/ssafy-verify/token.ts");
+
+const tokenModulePromise = import(
+  new URL("../src/lib/ssafy-verify/token.ts", import.meta.url).href,
+) as Promise<TokenModule>;
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("SSAFY Verify User Auth token exchange emits redacted request and response trace", async () => {
+  const { exchangeSsafyVerificationCode } = await tokenModulePromise;
+  const traces: unknown[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    assert.equal(String(input), "https://verify.example.com/verify/token");
+    assert.equal(init?.method, "POST");
+    const body = new URLSearchParams(String(init?.body ?? ""));
+    assert.equal(body.get("code"), "verify-code-secret");
+    assert.equal(body.get("code_verifier"), "pkce-verifier-secret");
+    assert.equal(body.get("client_secret"), "client-secret");
+
+    return jsonResponse({
+      verification_token: "verification-token-secret-with-minimum-length",
+      scope: "ssafy.verify ssafy.name ssafy.mattermost_id",
+      result: {
+        verification_id: "verify-123",
+      },
+    });
+  };
+
+  const result = await exchangeSsafyVerificationCode(
+    {
+      code: "verify-code-secret",
+      codeVerifier: "pkce-verifier-secret",
+      redirectUri: "https://ssartnership.example.com/auth/ssafy",
+      iss: "https://verify.example.com",
+    },
+    {
+      issuer: "https://verify.example.com",
+      clientId: "public-client",
+      clientSecret: "client-secret",
+      redirectUris: ["https://ssartnership.example.com/auth/ssafy"],
+    },
+    {
+      fetch: fetchImpl,
+      now: () => 0,
+      trace: (event) => {
+        traces.push(event);
+      },
+    },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(traces.length, 1);
+  assert.deepEqual(traces[0], {
+    source: "user-auth",
+    operation: "verification_code_exchange",
+    method: "POST",
+    path: "/verify/token",
+    scopes: [],
+    startedAt: "1970-01-01T00:00:00.000Z",
+    durationMs: 0,
+    status: 200,
+    ok: true,
+    request: {
+      contentType: "application/x-www-form-urlencoded",
+      fields: ["grant_type", "client_id", "code", "code_verifier", "client_secret"],
+      grantType: "verification_code",
+      clientId: "public-client",
+      hasClientSecret: true,
+      hasCode: true,
+      hasCodeVerifier: true,
+      scope: null,
+    },
+    response: {
+      keys: ["result", "scope", "verification_token"],
+      dataKeys: [],
+      errorKeys: [],
+      profileKeys: [],
+      resultsCount: null,
+      targetsCount: null,
+      requestId: null,
+      errorCode: null,
+      status: null,
+      campaignId: null,
+      notificationId: null,
+      hasAccessToken: false,
+      hasVerificationToken: true,
+      tokenType: null,
+      scope: "ssafy.verify ssafy.name ssafy.mattermost_id",
+      expiresIn: null,
+      verificationId: "verify-123",
+    },
+    errorCode: null,
+    providerRequestId: null,
+  });
+
+  const serialized = JSON.stringify(traces);
+  assert.equal(serialized.includes("verify-code-secret"), false);
+  assert.equal(serialized.includes("pkce-verifier-secret"), false);
+  assert.equal(serialized.includes("client-secret"), false);
+  assert.equal(serialized.includes("verification-token-secret-with-minimum-length"), false);
+});


### PR DESCRIPTION
## Summary
- SSAFY Verify User Auth `/verify/token`과 Server API `/server/token`, `/v1/*` 호출에 request/response 추적 로그를 추가했습니다.
- 로그는 `auth_security_logs`의 `ssafy_verify_api_trace` 이벤트로 남기고, code/client_secret/access_token/verification_token/raw Mattermost payload 값은 저장하지 않도록 요약합니다.
- 회원가입 완료 API의 세션 만료, 입력 오류, 약관 불일치, 이미 가입/충돌, 조회 실패 경로도 `member_signup_complete` 로그로 남기도록 보강했습니다.

## Related Issue
Refs #59

## Branch Flow
`feat/ssafy-verify-api-trace` → `dev`

## Changes
- `src/lib/ssafy-verify/api-trace.ts`에 공통 trace event, request/response summarizer, auth security log writer를 추가했습니다.
- SSAFY Verify Server API 클라이언트와 User Auth token exchange에 trace hook을 연결했습니다.
- 가입, 비밀번호 재설정, 회원 동기화, 디렉터리 조회, 수동 회원 추가, Mattermost 알림 발송 경로에서 trace logger를 전달합니다.
- 관리자 로그 라벨에 `SSAFY Verify API 추적`을 추가했습니다.
- 서버 전용 provision re-export가 클라이언트 번들에 섞이지 않도록 수동 회원 추가 배럴 export를 정리했습니다.

## Test Plan
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`
- `npm run audit:security`
- `npm run build-storybook`
- `npm run test-storybook`

## Checklist
- [x] Verify request/response 추적 로그 추가
- [x] token, secret, raw response 값 비저장 테스트 추가
- [x] 회원가입 중단/실패 지점 로그 보강
- [x] 로컬 검증 통과
