### PR TITLE
fix: SSAFY Verify 백필 토큰 발급 중복 완화

### DIFF
--- a/src/lib/mm-member-sync/snapshot.ts
+++ b/src/lib/mm-member-sync/snapshot.ts
@@ -48,17 +48,19 @@ export async function getSenderSessionForYear(
 
 export async function fetchMemberSnapshotByUserId(
   userId: string,
+  clientOverride?: ReturnType<typeof createSsafyVerifyServerApiClient>,
 ): Promise<MemberSyncSnapshot | null> {
-  const client = createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
-    trace: createSsafyVerifyApiTraceLogger({
-      actorType: "system",
-      identifier: userId,
-      properties: {
-        flow: "member_profile_sync",
-        mattermostUserId: userId,
-      },
-    }),
-  });
+  const client = clientOverride
+    ?? createSsafyVerifyServerApiClient(getSsafyVerifyServerApiConfig(), {
+      trace: createSsafyVerifyApiTraceLogger({
+        actorType: "system",
+        identifier: userId,
+        properties: {
+          flow: "member_profile_sync",
+          mattermostUserId: userId,
+        },
+      }),
+    });
   const payload = await client.getMattermostUserProfile(userId).catch((error) => {
     if (error instanceof SsafyVerifyServerApiError && error.status === 404) {
       return null;
@@ -77,13 +79,17 @@ export async function resolveMemberSnapshotForYears(
   member: MemberRow,
   candidateYears: number[],
   cache: Map<number, Promise<SenderSession>>,
+  clientOverride?: ReturnType<typeof createSsafyVerifyServerApiClient>,
 ) {
   let lastError: Error | null = null;
 
   for (const senderYear of candidateYears) {
     try {
       await getSenderSessionForYear(senderYear, cache);
-      const snapshot = await fetchMemberSnapshotByUserId(member.mm_user_id);
+      const snapshot = await fetchMemberSnapshotByUserId(
+        member.mm_user_id,
+        clientOverride,
+      );
       if (!snapshot) {
         continue;
       }

--- a/src/lib/mm-member-sync/sync.ts
+++ b/src/lib/mm-member-sync/sync.ts
@@ -1,3 +1,5 @@
+import { createSsafyVerifyApiTraceLogger } from "@/lib/ssafy-verify/api-trace";
+import { getSsafyVerifyServerApiConfig } from "@/lib/ssafy-verify/config";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import {
   getMemberSyncCandidateYears,
@@ -13,6 +15,7 @@ import {
   type SenderSession,
   wrapMmMemberSyncDbError,
 } from "./shared";
+import { createSsafyVerifyServerApiClient } from "@/lib/ssafy-verify/server-api";
 
 function buildMemberSyncSummary(result: MemberSyncResult) {
   const summaryParts = [`@${result.snapshot.mmUsername}`];
@@ -144,6 +147,7 @@ export async function syncMemberSnapshot(
 async function syncMembersForYear(
   yearMembers: MemberRow[],
   senderSessionCache: Map<number, Promise<SenderSession>>,
+  ssafyVerifyClient: ReturnType<typeof createSsafyVerifyServerApiClient>,
 ): Promise<MemberSyncYearBatchResult> {
   const results: MemberSyncResult[] = [];
   const failures: Array<{ memberId: string; mmUserId: string; reason: string }> = [];
@@ -154,6 +158,7 @@ async function syncMembersForYear(
         member,
         getMemberSyncCandidateYears(member.year),
         senderSessionCache,
+        ssafyVerifyClient,
       );
       if (!resolved) {
         failures.push({
@@ -193,10 +198,22 @@ export async function syncMemberById(
   }
 
   const senderSessionCache = new Map<number, Promise<SenderSession>>();
+  const ssafyVerifyClient = createSsafyVerifyServerApiClient(
+    getSsafyVerifyServerApiConfig(),
+    {
+      trace: createSsafyVerifyApiTraceLogger({
+        actorType: "system",
+        properties: {
+          flow: "member_profile_sync",
+        },
+      }),
+    },
+  );
   const resolved = await resolveMemberSnapshotForYears(
     member,
     getMemberSyncCandidateYears(member.year),
     senderSessionCache,
+    ssafyVerifyClient,
   );
   if (!resolved) {
     return null;
@@ -227,10 +244,25 @@ export async function syncMembersBySelectableYears(): Promise<MemberSyncBatchRes
   });
 
   const senderSessionCache = new Map<number, Promise<SenderSession>>();
+  const ssafyVerifyClient = createSsafyVerifyServerApiClient(
+    getSsafyVerifyServerApiConfig(),
+    {
+      trace: createSsafyVerifyApiTraceLogger({
+        actorType: "system",
+        properties: {
+          flow: "member_profile_sync",
+        },
+      }),
+    },
+  );
   const orderedYears = [...years].sort((a, b) => b - a);
   const yearResults = await Promise.all(
     orderedYears.map((year) =>
-      syncMembersForYear(groupedMembers.get(year) ?? [], senderSessionCache),
+      syncMembersForYear(
+        groupedMembers.get(year) ?? [],
+        senderSessionCache,
+        ssafyVerifyClient,
+      ),
     ),
   );
 

--- a/src/lib/ssafy-verify/server-api.ts
+++ b/src/lib/ssafy-verify/server-api.ts
@@ -92,6 +92,7 @@ type CachedToken = {
   accessToken: string;
   expiresAtMs: number;
 };
+type InFlightToken = Promise<CachedToken>;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -428,6 +429,7 @@ export function createSsafyVerifyServerApiClient(
   const now = options.now ?? (() => Date.now());
   const trace = options.trace ?? null;
   const tokenCache = new Map<string, CachedToken>();
+  const inFlightToken = new Map<string, InFlightToken>();
 
   async function fetchJson(
     url: string,
@@ -540,68 +542,82 @@ export function createSsafyVerifyServerApiClient(
       return cached.accessToken;
     }
 
-    const body = new URLSearchParams({
-      grant_type: "client_credentials",
-      client_id: config.clientId,
-      client_secret: config.clientSecret,
-    });
-    if (scope) {
-      body.set("scope", scope);
+    const inFlight = inFlightToken.get(scope);
+    if (inFlight) {
+      return (await inFlight).accessToken;
     }
 
-    const payload = await fetchJson(
-      joinUrl(config.apiBaseUrl, "/server/token"),
-      {
-        method: "POST",
-        headers: {
-          "cache-control": "no-store",
-          "content-type": "application/x-www-form-urlencoded",
+    const nextTokenRequest: InFlightToken = (async () => {
+      const body = new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+      });
+      if (scope) {
+        body.set("scope", scope);
+      }
+
+      const payload = await fetchJson(
+        joinUrl(config.apiBaseUrl, "/server/token"),
+        {
+          method: "POST",
+          headers: {
+            "cache-control": "no-store",
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+          cache: "no-store",
         },
-        body: body.toString(),
-        cache: "no-store",
-      },
-      {
-        status: 502,
-        errorCode: "VERIFY_SERVER_TOKEN_FAILED",
-        message: "SSAFY Verify Server API 토큰 발급에 실패했습니다.",
-      },
-      {
-        operation: "client_credentials_token",
-        method: "POST",
-        path: "/server/token",
-        scopes: scope ? scope.split(" ") : [],
-        request: summarizeSsafyVerifyFormTraceRequest(body),
-      },
-    );
+        {
+          status: 502,
+          errorCode: "VERIFY_SERVER_TOKEN_FAILED",
+          message: "SSAFY Verify Server API 토큰 발급에 실패했습니다.",
+        },
+        {
+          operation: "client_credentials_token",
+          method: "POST",
+          path: "/server/token",
+          scopes: scope ? scope.split(" ") : [],
+          request: summarizeSsafyVerifyFormTraceRequest(body),
+        },
+      );
 
-    if (!isRecord(payload) || typeof payload.access_token !== "string") {
-      throw new SsafyVerifyServerApiError({
-        status: 502,
-        errorCode: "VERIFY_SERVER_TOKEN_INVALID",
-        message: "SSAFY Verify Server API 토큰 응답을 확인하지 못했습니다.",
-      });
+      if (!isRecord(payload) || typeof payload.access_token !== "string") {
+        throw new SsafyVerifyServerApiError({
+          status: 502,
+          errorCode: "VERIFY_SERVER_TOKEN_INVALID",
+          message: "SSAFY Verify Server API 토큰 응답을 확인하지 못했습니다.",
+        });
+      }
+      if (
+        typeof payload.token_type === "string" &&
+        payload.token_type.toLowerCase() !== "bearer"
+      ) {
+        throw new SsafyVerifyServerApiError({
+          status: 502,
+          errorCode: "VERIFY_SERVER_TOKEN_INVALID",
+          message: "SSAFY Verify Server API 토큰 응답을 확인하지 못했습니다.",
+        });
+      }
+
+      const expiresIn =
+        typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in)
+          ? payload.expires_in
+          : DEFAULT_TOKEN_TTL_SECONDS;
+      const cachedToken = {
+        accessToken: payload.access_token,
+        expiresAtMs: now() + Math.max(0, expiresIn * 1000 - TOKEN_REFRESH_SKEW_MS),
+      };
+      tokenCache.set(scope, cachedToken);
+      return cachedToken;
+    })();
+    inFlightToken.set(scope, nextTokenRequest);
+
+    try {
+      return (await nextTokenRequest).accessToken;
+    } finally {
+      inFlightToken.delete(scope);
     }
-    if (
-      typeof payload.token_type === "string" &&
-      payload.token_type.toLowerCase() !== "bearer"
-    ) {
-      throw new SsafyVerifyServerApiError({
-        status: 502,
-        errorCode: "VERIFY_SERVER_TOKEN_INVALID",
-        message: "SSAFY Verify Server API 토큰 응답을 확인하지 못했습니다.",
-      });
-    }
-
-    const expiresIn =
-      typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in)
-        ? payload.expires_in
-        : DEFAULT_TOKEN_TTL_SECONDS;
-    tokenCache.set(scope, {
-      accessToken: payload.access_token,
-      expiresAtMs: now() + Math.max(0, expiresIn * 1000 - TOKEN_REFRESH_SKEW_MS),
-    });
-
-    return payload.access_token;
   }
 
   async function requestJson(input: {

--- a/tests/ssafy-verify-server-api.test.mts
+++ b/tests/ssafy-verify-server-api.test.mts
@@ -223,6 +223,63 @@ test("SSAFY Verify Server API client caches client_credentials tokens per scope"
   assert.equal(calls[2]?.authorization, "Bearer access-token-1");
 });
 
+test("SSAFY Verify Server API dedupes concurrent token requests", async () => {
+  const { createSsafyVerifyServerApiClient } = await serverApiModulePromise;
+  const calls: Array<string> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.endsWith("/server/token")) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return jsonResponse({
+        access_token: "access-token-1",
+        token_type: "Bearer",
+        expires_in: 600,
+      });
+    }
+
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get("authorization"), "Bearer access-token-1");
+    return jsonResponse({
+      ok: true,
+      data: {
+        profile: {
+          mattermost_user_id: String(url.endsWith("/mattermost-users/mm.user_123-abc/profile")
+            ? "mm.user_123-abc"
+            : "mm.user_456-def"),
+          name: "김싸피",
+        },
+      },
+      request_id: "req_123",
+    });
+  };
+
+  const client = createSsafyVerifyServerApiClient(
+    {
+      issuer: "https://verify.example.com",
+      apiBaseUrl: "https://verify.example.com/v1",
+      clientId: "server-api-client",
+      clientSecret: "server-secret",
+    },
+    { fetch: fetchImpl },
+  );
+
+  const [first, second] = await Promise.all([
+    client.getMattermostUserProfile("mm.user_123-abc"),
+    client.getMattermostUserProfile("mm.user_456-def"),
+  ]);
+  const firstProfile = first.data?.profile?.mattermost_user_id;
+  const secondProfile = second.data?.profile?.mattermost_user_id;
+  assert.equal(firstProfile, "mm.user_123-abc");
+  assert.equal(secondProfile, "mm.user_456-def");
+
+  const tokenRequests = calls.filter((value) => value === "https://verify.example.com/v1/server/token");
+  assert.equal(tokenRequests.length, 1);
+  assert.equal(calls.length, 3);
+  assert.equal(calls[1]?.startsWith("https://verify.example.com/v1/mattermost-users/"), true);
+  assert.equal(calls[2]?.startsWith("https://verify.example.com/v1/mattermost-users/"), true);
+});
+
 test("SSAFY Verify Server API normalizes stable public errors", async () => {
   const {
     SsafyVerifyServerApiError,


### PR DESCRIPTION
## Summary
- 회원 백필/단건 프로필 동기화에서 SSAFY Verify Server API client를 실행 단위로 재사용합니다.
- Server API client의 동일 scope client_credentials 토큰 발급 요청을 in-flight dedupe 처리합니다.
- 동시 프로필 조회가 `/server/token`을 한 번만 호출하는 회귀 테스트를 추가합니다.

## Related Issue
Closes #62

## Branch Flow
`fix/ssafy-verify-token-rate-limit` -> `dev`

## Changes
- `syncMembersBySelectableYears`, `syncMemberById`가 공유 SSAFY Verify client를 생성해 snapshot 조회에 전달합니다.
- `fetchMemberSnapshotByUserId`, `resolveMemberSnapshotForYears`가 optional client override를 받아 기존 단건 호출 호환성을 유지합니다.
- `createSsafyVerifyServerApiClient`가 같은 scope의 진행 중 token request를 공유합니다.

## Test Plan
- [x] `npm run test -- tests/ssafy-verify-server-api.test.mts`
- [x] `npx eslint src/lib/mm-member-sync/sync.ts src/lib/mm-member-sync/snapshot.ts src/lib/ssafy-verify/server-api.ts tests/ssafy-verify-server-api.test.mts`
- [x] `npm run build`
- [x] `npx tsc --noEmit --pretty false`
- [x] pre-push hook: `npm run lint`
- [x] pre-push hook: `npm test`
- [x] pre-push hook: `npm run build`

## Checklist
- [x] No secrets or raw credentials added
- [x] Existing trace payloads remain redacted
- [x] Backward-compatible fallback path preserved for direct snapshot lookup
